### PR TITLE
Fix worker auth and SQLite remote apply

### DIFF
--- a/src/sync/apply-remote-changes.test.ts
+++ b/src/sync/apply-remote-changes.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeDataForSqliteBinding } from "./apply-remote-changes";
+
+describe("sanitizeDataForSqliteBinding", () => {
+  it("serializes object and array values before SQLite binding", () => {
+    const sanitized = sanitizeDataForSqliteBinding({
+      enabled: true,
+      libOptions: { mode: "fsrs", queue: ["due", "new"] },
+      fsrsParams: [0.4, 0.6],
+      orderMode: "fsrs",
+      practiceTimeLimit: 300,
+      nullable: null,
+    });
+
+    expect(sanitized).toEqual({
+      enabled: 1,
+      libOptions: JSON.stringify({ mode: "fsrs", queue: ["due", "new"] }),
+      fsrsParams: JSON.stringify([0.4, 0.6]),
+      orderMode: "fsrs",
+      practiceTimeLimit: 300,
+      nullable: null,
+    });
+  });
+});

--- a/src/sync/apply-remote-changes.ts
+++ b/src/sync/apply-remote-changes.ts
@@ -28,14 +28,29 @@ const isForeignKeyConstraintFailure = (e: unknown): boolean => {
   return /FOREIGN KEY constraint failed/i.test(msg);
 };
 
-const sanitizeData = (data: Record<string, unknown>) => {
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+export const sanitizeDataForSqliteBinding = (
+  data: Record<string, unknown>
+) => {
   const sanitized = { ...data };
-  // Convert boolean to integer for SQLite
+
+  // Convert JS values to types sql.js can bind safely.
   for (const key in sanitized) {
     if (typeof sanitized[key] === "boolean") {
       sanitized[key] = sanitized[key] ? 1 : 0;
+      continue;
+    }
+
+    if (Array.isArray(sanitized[key]) || isPlainObject(sanitized[key])) {
+      sanitized[key] = JSON.stringify(sanitized[key]);
     }
   }
+
   return sanitized;
 };
 
@@ -155,7 +170,7 @@ export async function applyRemoteChangesToLocalDb(params: {
           }
         } else {
           // Upsert local
-          const sanitizedData = sanitizeData(change.data);
+          const sanitizedData = sanitizeDataForSqliteBinding(change.data);
 
           const adapterPk = adapter.primaryKey;
           const conflictTarget = Array.isArray(adapterPk)

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -328,7 +328,7 @@ export interface Env {
   /** When "true", ignores HYPERDRIVE and connects via DATABASE_URL directly. */
   BYPASS_HYPERDRIVE?: string;
   SUPABASE_URL: string;
-  SUPABASE_JWT_SECRET: string;
+  SUPABASE_JWT_SECRET?: string;
   /** When "true", enables debug logging (console.log statements). */
   WORKER_DEBUG?: string;
   /** When "true", emits perf timing logs for sync phases. */
@@ -683,7 +683,7 @@ function getJwks(supabaseUrl: string): ReturnType<typeof createRemoteJWKSet> {
 
 async function verifyJwt(
   request: Request,
-  secret: string,
+  secret: string | undefined,
   supabaseUrl: string
 ): Promise<string | null> {
   const authHeader = request.headers.get("Authorization");
@@ -710,6 +710,12 @@ async function verifyJwt(
       payload = result.payload;
     } else {
       // HS256 (Supabase CLI < 2.75): symmetric secret
+      if (!secret) {
+        console.error(
+          "[AUTH] HS256 token received but SUPABASE_JWT_SECRET is not configured"
+        );
+        return null;
+      }
       debug.log("[AUTH] Using HS256 verification");
       const result = await jwtVerify(token, new TextEncoder().encode(secret));
       payload = result.payload;
@@ -1592,12 +1598,6 @@ async function fetch(request: Request, env: Env): Promise<Response> {
     if (request.method === "POST" && url.pathname === "/api/sync") {
       debug.log(`[HTTP] POST /api/sync received`);
       perfLog(perfDebugEnabled, "http.sync.request.received");
-
-      // Validate environment configuration
-      if (!env.SUPABASE_JWT_SECRET) {
-        console.error("[HTTP] SUPABASE_JWT_SECRET not configured");
-        return errorResponse("Server configuration error", 500, corsHeaders);
-      }
 
       // Authenticate
       const authStartedAt = Date.now();


### PR DESCRIPTION
## Summary

This fixes two sync blockers in oosync that showed up while validating CubeFSRS end-to-end sync:

- stop requiring `SUPABASE_JWT_SECRET` for all worker auth flows
- keep ES256 token verification on the JWKS path and only require the secret for HS256 tokens
- serialize plain objects and arrays before binding remote change data into SQLite
- add a regression test covering the SQLite binding sanitizer

## Problem

There were two separate failures:

1. The worker rejected `/api/sync` requests with a server configuration error whenever `SUPABASE_JWT_SECRET` was unset, even when Supabase was issuing `ES256` access tokens that should be verified via JWKS.

2. After auth was fixed, sync-down could still fail while applying remote rows into local SQLite because object/array values were passed directly into sql.js bindings. That surfaced as an "unknown type ([object Object])" binding error.

## Changes

### Worker auth
- make `SUPABASE_JWT_SECRET` optional in the worker env
- for `ES256`, continue verifying with JWKS from `SUPABASE_URL`
- for `HS256`, fail auth only if a secret is actually needed and missing
- remove the global early-return that treated a missing secret as a server misconfiguration for every request

### SQLite remote apply
- replace the old boolean-only sanitization with a SQLite binding sanitizer that:
  - converts booleans to `0` / `1`
  - serializes arrays with `JSON.stringify(...)`
  - serializes plain objects with `JSON.stringify(...)`
- use the new sanitizer in the remote upsert path

### Tests
- add a focused unit test covering object/array serialization before SQLite binding

## Why this is the right fix

These failures belong in oosync, not the consumer app:

- auth algorithm handling is part of the generic worker runtime
- SQLite binding normalization is part of the generic remote-apply runtime

That keeps consumer repos from needing environment-specific workarounds or app-specific patching for sync correctness.

## Validation

- `npm run typecheck`
- `npx vitest run src/sync/apply-remote-changes.test.ts`

Downstream validation in CubeFSRS also passed after pulling these changes into the app and rerunning the sync round-trip E2E flow.