### PR TITLE
Upgrade to TypeScript 6.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/node": "^25.3.0",
         "@types/sql.js": "^1.4.9",
         "tsx": "^4.21.0",
-        "typescript": "~5.9.3",
+        "typescript": "6.0.2",
         "vitest": "^4.0.18"
       }
     },
@@ -1698,9 +1698,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.3",
+    "@cloudflare/workers-types": "^4.20260219.0",
     "@types/node": "^25.3.0",
     "@types/sql.js": "^1.4.9",
-    "@cloudflare/workers-types": "^4.20260219.0",
     "tsx": "^4.21.0",
-    "typescript": "~5.9.3",
+    "typescript": "6.0.2",
     "vitest": "^4.0.18"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["node"],

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -9,6 +9,7 @@
     "strict": true,
     "allowImportingTsExtensions": true,
     "noEmit": true,
+    "ignoreDeprecations": "6.0",
     "baseUrl": "../..",
     "paths": {
       "@shared-generated/*": ["shared/generated/*"],


### PR DESCRIPTION
Upgrades oosync to TypeScript 6.0.2, refreshes the lockfile, and updates the root and worker TypeScript configs for TS6 compatibility.

Notable changes:
- refresh package and lockfile dependencies
- update root and worker tsconfig settings for the upgraded compiler

Validation:
- ran the relevant validation checks for this repo after the upgrade

Refs sboagy/rhizome#7
Refs sboagy/rhizome#8