### PR TITLE
 🐛 fix: align sqlite-wasm adapter with sql-js statement reads

### DIFF
--- a/src/runtime/sqlite-wasm-adapter.test.ts
+++ b/src/runtime/sqlite-wasm-adapter.test.ts
@@ -60,6 +60,17 @@ describe("sqlite-wasm adapter", () => {
     expect(select.step()).toBe(false);
     select.free();
 
+    const getWithoutStep = db.prepare(
+      "SELECT id, n FROM item WHERE id = ? LIMIT 1"
+    );
+    expect(getWithoutStep.get(["a"])).toEqual(["a", 1]);
+    expect(getWithoutStep.getAsObject(["c"])).toEqual({
+      id: "c",
+      n: 3,
+    });
+    expect(getWithoutStep.get(["missing"])).toEqual([]);
+    getWithoutStep.free();
+
     expect(db.exec("SELECT COUNT(*) AS total FROM item")[0]?.values).toEqual([
       [3],
     ]);

--- a/src/runtime/sqlite-wasm-adapter.ts
+++ b/src/runtime/sqlite-wasm-adapter.ts
@@ -117,6 +117,7 @@ function bindIfProvided(
 
 class SqliteWasmStatementAdapter implements IRawSqliteStatement {
   private readonly statement: Sqlite3PreparedStatement;
+  private hasCurrentRow = false;
 
   constructor(statement: Sqlite3PreparedStatement) {
     this.statement = statement;
@@ -125,33 +126,56 @@ class SqliteWasmStatementAdapter implements IRawSqliteStatement {
   run(
     params?: SqliteCompatibleValue[] | Record<string, SqliteCompatibleValue>
   ): void {
+    this.statement.reset(true);
     bindIfProvided(this.statement, params);
     this.statement.step();
     this.statement.reset(true);
+    this.hasCurrentRow = false;
   }
 
   bind(
     params?: SqliteCompatibleValue[] | Record<string, SqliteCompatibleValue>
   ): boolean {
+    this.statement.reset(true);
     bindIfProvided(this.statement, params);
+    this.hasCurrentRow = false;
     return true;
   }
 
   step(): boolean {
-    return this.statement.step();
+    this.hasCurrentRow = this.statement.step();
+    return this.hasCurrentRow;
+  }
+
+  private stepIfNeeded(
+    params?: SqliteCompatibleValue[] | Record<string, SqliteCompatibleValue>
+  ): boolean {
+    if (params) {
+      this.statement.reset(true);
+      bindIfProvided(this.statement, params);
+      this.hasCurrentRow = false;
+    }
+    if (!this.hasCurrentRow) {
+      this.hasCurrentRow = this.statement.step();
+    }
+    return this.hasCurrentRow;
   }
 
   get(
     params?: SqliteCompatibleValue[] | Record<string, SqliteCompatibleValue>
   ): SqliteCompatibleValue[] {
-    bindIfProvided(this.statement, params);
+    if (!this.stepIfNeeded(params)) {
+      return [];
+    }
     return normalizeRow(this.statement.get([]));
   }
 
   getAsObject(
     params?: SqliteCompatibleValue[] | Record<string, SqliteCompatibleValue>
   ): Record<string, SqliteCompatibleValue> {
-    bindIfProvided(this.statement, params);
+    if (!this.stepIfNeeded(params)) {
+      return {};
+    }
     const row = this.statement.get({}) as Record<string, unknown>;
     return Object.fromEntries(
       Object.entries(row).map(([key, value]) => [

--- a/src/sync/outbox.test.ts
+++ b/src/sync/outbox.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
 import {
+  backfillOutboxForTable,
   clearOldOutboxItems,
   fetchLocalRowByPrimaryKey,
   getDrizzleTable,
@@ -41,6 +43,53 @@ function configureTestRuntime(): void {
     },
     syncPushQueue: queueColumns,
     localSchema: { entityTable: { name: "entity_table" } },
+    getSqliteInstance: async () => null,
+    loadOutboxBackupForUser: async () => null,
+    clearOutboxBackupForUser: async () => {},
+    replayOutboxBackup: () => ({ applied: 0, skipped: 0, errors: [] }),
+    enableSyncTriggers: () => {},
+    suppressSyncTriggers: () => {},
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+  } as unknown as SyncRuntime;
+
+  setSyncRuntime(runtime);
+}
+
+function configureBackfillRuntime(): void {
+  const entityTable = sqliteTable("entity_table", {
+    id: text("id").primaryKey(),
+    lastModifiedAt: text("last_modified_at"),
+  });
+
+  const queueColumns = {
+    id: { name: "id" },
+    tableName: { name: "table_name" },
+    rowId: { name: "row_id" },
+  } as unknown as SyncPushQueueTable;
+
+  const runtime = {
+    schema: {
+      syncableTables: ["entity_table"],
+      tableRegistry: {
+        entity_table: {
+          primaryKey: "id",
+          uniqueKeys: null,
+          timestamps: ["last_modified_at"],
+          booleanColumns: [],
+          supportsIncremental: true,
+          hasDeletedFlag: false,
+        },
+      },
+      tableSyncOrder: {},
+      tableToSchemaKey: { entity_table: "entityTable" },
+    },
+    syncPushQueue: queueColumns,
+    localSchema: { entityTable },
     getSqliteInstance: async () => null,
     loadOutboxBackupForUser: async () => null,
     clearOutboxBackupForUser: async () => {},
@@ -263,6 +312,39 @@ describe("outbox utilities", () => {
       await clearOldOutboxItems(db, 7 * 24 * 60 * 60 * 1000);
 
       expect(deleteCalls).toBe(1);
+    });
+  });
+
+  describe("backfillOutboxForTable", () => {
+    it("skips device-scoped backfill when the table lacks device_id", async () => {
+      configureBackfillRuntime();
+
+      let insertedRows: unknown;
+      const db = {
+        all: async () => {
+          return [{ id: "entity-1" }];
+        },
+        select: () => ({
+          from: () => ({
+            where: async () => [],
+          }),
+        }),
+        insert: () => ({
+          values: (values: unknown) => {
+            insertedRows = values;
+          },
+        }),
+      } as unknown as SqliteDatabase;
+
+      const count = await backfillOutboxForTable(
+        db,
+        "entity_table",
+        "2025-01-01T00:00:00.000Z",
+        "local-device"
+      );
+
+      expect(count).toBe(0);
+      expect(insertedRows).toBeUndefined();
     });
   });
 

--- a/src/sync/outbox.ts
+++ b/src/sync/outbox.ts
@@ -8,7 +8,7 @@
  * @module lib/sync/outbox
  */
 
-import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, getTableColumns, inArray, sql } from "drizzle-orm";
 import type { AnySQLiteTable } from "drizzle-orm/sqlite-core";
 import { getPrimaryKey } from "../shared/table-meta";
 import { toCamelCase } from "./casing";
@@ -44,6 +44,14 @@ function getDrizzleTableFromSchema(
   const schemaKey = tableToSchemaKey[tableName];
   if (!schemaKey) return undefined;
   return (localSchema as Record<string, AnySQLiteTable>)[schemaKey];
+}
+
+function hasDrizzleColumn(tableName: string, columnName: string): boolean {
+  const table = getDrizzleTableFromSchema(tableName);
+  if (!table) return false;
+  return Object.values(getTableColumns(table)).some(
+    (column) => column.name === columnName
+  );
 }
 
 function randomHexId(bytesLength = 16): string {
@@ -165,6 +173,11 @@ export async function backfillOutboxForTable(
   // When applying remote changes during syncDown, we suppress triggers. Any rows written in
   // that window will have their remote device_id (or null). We only want to backfill rows
   // written by THIS device while triggers were suppressed (e.g., user edits).
+  const hasDeviceIdColumn = hasDrizzleColumn(tableName, "device_id");
+  if (deviceId && !hasDeviceIdColumn) {
+    return 0;
+  }
+
   const deviceClause = deviceId ? ` AND "device_id" = '${deviceId}'` : "";
 
   const query = sql.raw(


### PR DESCRIPTION
Update the sqlite-wasm adapter so Drizzle-style stmt.get(params) and stmt.getAsObject(params) calls bind and step rows correctly, including no-row results. Also skip device-scoped outbox backfills for tables without device_id.

Validated with oosync unit tests, typecheck, lint, and downstream TuneTrees e2e.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for parameterized database query operations and sync backfill scenarios.

* **Bug Fixes**
  * Improved database statement execution state management for consistent operation behavior.
  * Enhanced incremental sync backfill to safely skip unsupported schema configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->