### PR TITLE
 🐛 fix(codegen): compute SQLite schema imports dynamically to avoid unused-import warnings

### DIFF
--- a/src/codegen-schema.ts
+++ b/src/codegen-schema.ts
@@ -2290,21 +2290,6 @@ function buildIndexItems(params: {
   return configItems;
 }
 
-function hasEmittableIndexItems(
-  groupedIndexes: Map<string, IIndexKeyRow[]>,
-  tableNames: string[]
-): boolean {
-  return tableNames.some((tableName) =>
-    getGroupedRowsForTable(groupedIndexes, tableName).some((rows) => {
-      const sorted = getSortedRowsByPosition(rows);
-      return (
-        !!sorted[0]?.index_name &&
-        sorted.every((row) => parseIndexKeyToColumnName(row.keydef) !== null)
-      );
-    })
-  );
-}
-
 function buildSqliteConfigItems(params: {
   tableName: string;
   pkCols: IConstraintColumnRow[];
@@ -2401,37 +2386,45 @@ function buildSchemaTs(params: {
     params.strict
   );
 
-  const sqliteCoreImports = [
-    ...(hasEmittableIndexItems(idxByTableIndex, tables) ? ["index"] : []),
+  // Generate table definitions first so we can compute which drizzle
+  // builders are actually used (avoids unused-import lint errors).
+  const tableLines = tables.flatMap((tableName) => {
+    const ident = tableIdentByName.get(tableName);
+    return ident
+      ? buildSqliteTableLines({
+          tableName,
+          ident,
+          tableColumns: getSortedTableColumns(colsByTable, tableName),
+          pkCols: getSortedRowsByPosition(pkByTable.get(tableName)),
+          fkByTableCol,
+          tableIdentByName,
+          uniqueByTableConstraint,
+          idxByTableIndex,
+          strict: params.strict,
+        })
+      : [];
+  });
+
+  const tableContent = tableLines.join("\n");
+  const ALL_SQLITE_BUILDERS = [
+    "index",
     "integer",
     "primaryKey",
     "real",
     "sqliteTable",
     "text",
     "uniqueIndex",
-  ].join(", ");
+  ] as const;
+  const usedBuilders = ALL_SQLITE_BUILDERS.filter(
+    (b) => new RegExp(String.raw`\b${b}\(`).test(tableContent)
+  );
 
   return [
     createHeader({ schema: params.schema }),
-    `import { ${sqliteCoreImports} } from "drizzle-orm/sqlite-core";`,
+    `import { ${usedBuilders.join(", ")} } from "drizzle-orm/sqlite-core";`,
     'import { sqliteSyncColumns } from "oosync/shared/sync-columns";',
     "",
-    ...tables.flatMap((tableName) => {
-      const ident = tableIdentByName.get(tableName);
-      return ident
-        ? buildSqliteTableLines({
-            tableName,
-            ident,
-            tableColumns: getSortedTableColumns(colsByTable, tableName),
-            pkCols: getSortedRowsByPosition(pkByTable.get(tableName)),
-            fkByTableCol,
-            tableIdentByName,
-            uniqueByTableConstraint,
-            idxByTableIndex,
-            strict: params.strict,
-          })
-        : [];
-    }),
+    ...tableLines,
   ]
     .join("\n")
     .replace(/\n{3,}/g, "\n\n");

--- a/src/codegen-schema.ts
+++ b/src/codegen-schema.ts
@@ -2421,7 +2421,11 @@ function buildSchemaTs(params: {
 
   return [
     createHeader({ schema: params.schema }),
-    `import { ${usedBuilders.join(", ")} } from "drizzle-orm/sqlite-core";`,
+    ...(usedBuilders.length > 0
+      ? [
+          `import { ${usedBuilders.join(", ")} } from "drizzle-orm/sqlite-core";`,
+        ]
+      : []),
     'import { sqliteSyncColumns } from "oosync/shared/sync-columns";',
     "",
     ...tableLines,


### PR DESCRIPTION
Previously, `buildSchemaTs` hardcoded all drizzle-orm/sqlite-core builder imports (`index`, `integer`, `primaryKey`, `real`, `sqliteTable`, `text`, `uniqueIndex`), which caused lint errors when a consumer schema didn't use every builder (e.g., no non-unique indexes → unused `index` import).

Now the function generates table definitions first, scans the output for which builders are actually referenced, and emits only the needed imports — the same pattern already used by the PG schema builder (`getUsedPgBuilders`).

Also removed the now-unused `hasEmittableIndexItems` helper and switched the detection regex to `String.raw` to avoid unnecessary backslash escaping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved SQLite schema code generation by first producing all table definitions, then automatically detecting which SQL builder helpers are actually used and importing only those—resulting in leaner generated schema modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->