### PR TITLE
 ✨ feat(codegen): emit dependency-ordered syncable tables

### DIFF
--- a/src/codegen-schema.ts
+++ b/src/codegen-schema.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import postgres from "postgres";
+import { orderSyncableTablesByDependency } from "./codegen/table-order";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -2415,8 +2416,8 @@ function buildSchemaTs(params: {
     "text",
     "uniqueIndex",
   ] as const;
-  const usedBuilders = ALL_SQLITE_BUILDERS.filter(
-    (b) => new RegExp(String.raw`\b${b}\(`).test(tableContent)
+  const usedBuilders = ALL_SQLITE_BUILDERS.filter((b) =>
+    new RegExp(String.raw`\b${b}\(`).test(tableContent)
   );
 
   return [
@@ -3026,17 +3027,6 @@ async function main(): Promise<void> /* NOSONAR - codegen orchestration is inten
     columnDescriptionsByTable[row.table_name][row.column_name] = row.comment;
   }
 
-  const nextTableMeta = buildTableMetaTs({
-    schema: args.schema,
-    columns,
-    primaryKeys,
-    uniqueConstraints,
-    strict: args.strict,
-    syncableTables,
-    tableRegistryCore,
-    columnDescriptionsByTable,
-  });
-
   const changeCategoryByTable: Record<string, ChangeCategory> = {
     ...(config.tableMeta?.changeCategoryByTable ??
       EMPTY_CHANGE_CATEGORY_BY_TABLE),
@@ -3071,9 +3061,24 @@ async function main(): Promise<void> /* NOSONAR - codegen orchestration is inten
     foreignKeys,
     overrides: config.tableMeta?.tableSyncOrderOverrides ?? EMPTY_NUMBER_RECORD,
   });
+  const orderedSyncableTables = orderSyncableTablesByDependency({
+    syncableTables,
+    tableSyncOrder,
+  });
+
+  const nextTableMeta = buildTableMetaTs({
+    schema: args.schema,
+    columns,
+    primaryKeys,
+    uniqueConstraints,
+    strict: args.strict,
+    syncableTables: orderedSyncableTables,
+    tableRegistryCore,
+    columnDescriptionsByTable,
+  });
 
   const tableToSchemaKey = buildTableToSchemaKeyMap({
-    tables: syncableTables,
+    tables: orderedSyncableTables,
     overrides:
       config.tableMeta?.tableToSchemaKeyOverrides ?? EMPTY_STRING_RECORD,
   });
@@ -3084,7 +3089,7 @@ async function main(): Promise<void> /* NOSONAR - codegen orchestration is inten
       fromFile: outputAppTableMetaFile,
       toFile: outputTableMetaFile,
     }),
-    syncableTables,
+    syncableTables: orderedSyncableTables,
     changeCategoryByTable,
     normalizeDatetimeByTable,
     tableSyncOrder,
@@ -3100,7 +3105,7 @@ async function main(): Promise<void> /* NOSONAR - codegen orchestration is inten
   });
 
   const defaultWorkerConfig = buildDefaultWorkerConfig({
-    syncableTables,
+    syncableTables: orderedSyncableTables,
     columnsByTable,
     foreignKeys,
     tableRegistryCore,

--- a/src/codegen-schema.ts
+++ b/src/codegen-schema.ts
@@ -1482,7 +1482,7 @@ function buildTableRegistryHelperLines(): string[] {
     "export const TABLE_REGISTRY_MERGED: Record<SyncableTableName, TableMeta> = Object.fromEntries(",
     "  Object.entries(TABLE_REGISTRY_CORE).map(([tableName, core]) => {",
     "    const extras = TABLE_EXTRAS[tableName as SyncableTableName];",
-    "    return [tableName, { ...(core as TableMetaCore), ...extras }];",
+    "    return [tableName, { ...core, ...extras }];",
     "  })",
     ") as Record<SyncableTableName, TableMeta>;",
     "",
@@ -1557,7 +1557,7 @@ function buildAppTableMetaAccessorLines(): string[] {
     "  | ((row: Readonly<Record<string, unknown>>) => Record<string, unknown>)",
     "  | undefined {",
     "  const normalize = TABLE_REGISTRY[tableName]?.normalize;",
-    "  return normalize ? (row) => normalize(row as Record<string, unknown>) : undefined;",
+    "  return normalize ? (row) => normalize(row) : undefined;",
     "}",
     "",
     "export function isRegisteredTable(tableName: string): boolean {",
@@ -1637,7 +1637,6 @@ function buildAppTableMetaTs(params: {
       "\n  type SyncableTableName as GeneratedSyncableTableName," +
       "\n  SYNCABLE_TABLES as SYNCABLE_TABLES_GENERATED," +
       "\n  TABLE_REGISTRY_CORE," +
-      "\n  type TableMetaCore," +
       `\n} from ${JSON.stringify(params.generatedTableMetaImportPath)};`,
     "",
     ...buildAppTableMetaInterfaceLines(),

--- a/src/codegen/table-order.test.ts
+++ b/src/codegen/table-order.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { orderSyncableTablesByDependency } from "./table-order";
+
+describe("orderSyncableTablesByDependency", () => {
+  it("orders syncable tables by FK-derived dependency order", () => {
+    expect(
+      orderSyncableTablesByDependency({
+        syncableTables: ["child", "unrelated_b", "parent", "unrelated_a"],
+        tableSyncOrder: {
+          parent: 1,
+          child: 2,
+          unrelated_a: 3,
+          unrelated_b: 3,
+        },
+      })
+    ).toEqual(["parent", "child", "unrelated_a", "unrelated_b"]);
+  });
+
+  it("keeps deterministic order for tables without dependency metadata", () => {
+    expect(
+      orderSyncableTablesByDependency({
+        syncableTables: ["late_b", "known", "late_a"],
+        tableSyncOrder: {
+          known: 1,
+        },
+      })
+    ).toEqual(["known", "late_a", "late_b"]);
+  });
+});

--- a/src/codegen/table-order.ts
+++ b/src/codegen/table-order.ts
@@ -1,0 +1,11 @@
+export function orderSyncableTablesByDependency(params: {
+  syncableTables: string[];
+  tableSyncOrder: Record<string, number>;
+}): string[] {
+  return [...params.syncableTables].sort((a, b) => {
+    const orderA = params.tableSyncOrder[a] ?? Number.MAX_SAFE_INTEGER;
+    const orderB = params.tableSyncOrder[b] ?? Number.MAX_SAFE_INTEGER;
+    if (orderA !== orderB) return orderA - orderB;
+    return a.localeCompare(b);
+  });
+}

--- a/src/shared/protocol/sync-types.ts
+++ b/src/shared/protocol/sync-types.ts
@@ -6,9 +6,7 @@
  * and response, preventing protocol mismatches.
  */
 
-export type TableName = string;
-
-export interface SyncChange<TTableName extends string = TableName> {
+export interface SyncChange<TTableName extends string = string> {
   table: TTableName;
   rowId: string; // UUID or JSON composite key
   data: Record<string, unknown>; // The full row data
@@ -29,7 +27,7 @@ export interface SyncRequestOverrides {
   pullTables?: string[];
 }
 
-export interface SyncRequest<TTableName extends string = TableName> {
+export interface SyncRequest<TTableName extends string = string> {
   changes: Array<SyncChange<TTableName>>;
   lastSyncAt?: string; // ISO timestamp of last successful sync
   schemaVersion: number;
@@ -52,6 +50,13 @@ export interface SyncRequest<TTableName extends string = TableName> {
    */
   pageSize?: number;
 
+  /**
+   * Optional number of initial-sync table pages to coalesce into one response.
+   * The worker may clamp this to a safe maximum. Omit or set to 1 for the
+   * legacy one-table-page-per-response behavior.
+   */
+  initialPageCount?: number;
+
   /** Optional per-request collection values keyed by collection name. */
   collectionsOverride?: SyncCollectionsOverride;
   /** Optional per-request RPC param overrides keyed by RPC function name. */
@@ -60,7 +65,7 @@ export interface SyncRequest<TTableName extends string = TableName> {
   pullTables?: string[];
 }
 
-export interface SyncResponse<TTableName extends string = TableName> {
+export interface SyncResponse<TTableName extends string = string> {
   changes: Array<SyncChange<TTableName>>;
   syncedAt: string; // ISO timestamp of this sync
   error?: string;

--- a/src/shared/protocol/sync-types.ts
+++ b/src/shared/protocol/sync-types.ts
@@ -63,12 +63,23 @@ export interface SyncRequest<TTableName extends string = string> {
   rpcParamOverrides?: SyncRpcParamOverrides;
   /** Optional allowlist of tables to pull for this sync. */
   pullTables?: string[];
+
+  /**
+   * Optional request-scoped diagnostics hint. Workers may ignore this unless
+   * diagnostics are allowed by environment/configuration.
+   */
+  diagnostics?: boolean;
 }
 
 export interface SyncResponse<TTableName extends string = string> {
   changes: Array<SyncChange<TTableName>>;
   syncedAt: string; // ISO timestamp of this sync
   error?: string;
+  /**
+   * Human-readable diagnostic lines emitted only when diagnostics are enabled.
+   * These lines are not part of sync correctness and may change between
+   * versions; consumers should log them rather than parse them for behavior.
+   */
   debug?: string[];
 
   /**

--- a/src/sync/engine.test.ts
+++ b/src/sync/engine.test.ts
@@ -134,6 +134,9 @@ describe("SyncEngine initial sync paging", () => {
     expect(workerSyncMock.mock.calls.map((call) => call[2]?.pageSize)).toEqual([
       200, 100, 100,
     ]);
+    expect(
+      workerSyncMock.mock.calls.map((call) => call[2]?.initialPageCount)
+    ).toEqual([16, 16, 16]);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       "TT_LAST_SYNC_TIMESTAMP_user-1",
       "2024-01-01T00:00:00.000Z"
@@ -157,6 +160,7 @@ describe("SyncEngine initial sync paging", () => {
     expect(result.success).toBe(false);
     expect(workerSyncMock).toHaveBeenCalledTimes(1);
     expect(workerSyncMock.mock.calls[0][2]?.pageSize).toBe(200);
+    expect(workerSyncMock.mock.calls[0][2]?.initialPageCount).toBe(16);
     expect(result.errors[0]).toContain("Sync failed: 400");
   });
 });

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -12,7 +12,7 @@
 import type { SyncChange, SyncRequestOverrides } from "@oosync/shared/protocol";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { IRawSqliteExecResult } from "../runtime/sqlite-wasm-adapter";
-import { getAdapter, type SyncableTableName } from "./adapters";
+import { getAdapter } from "./adapters";
 import { applyRemoteChangesToLocalDb } from "./apply-remote-changes";
 import {
   backfillOutboxSince,
@@ -62,6 +62,7 @@ function getRuntimeState() {
 const SYNC_DIAGNOSTICS = import.meta.env.VITE_SYNC_DIAGNOSTICS === "true";
 
 const INITIAL_SYNC_PAGE_SIZE = 200;
+const INITIAL_SYNC_PAGE_COUNT = 16;
 const MIN_INITIAL_SYNC_PAGE_SIZE = 25;
 
 /** LocalStorage key prefix for persisting last sync timestamp across app restarts */
@@ -213,12 +214,12 @@ function sortOutboxItemsByDependency(items: OutboxItem[]): OutboxItem[] {
  * ```
  */
 export class SyncEngine {
-  private localDb: SqliteDatabase;
-  private supabase: SupabaseClient;
-  private config: SyncConfig;
+  private readonly localDb: SqliteDatabase;
+  private readonly supabase: SupabaseClient;
+  private readonly config: SyncConfig;
   private lastSyncTimestamp: string | null = null;
-  private userId: string;
-  private deviceId: string;
+  private readonly userId: string;
+  private readonly deviceId: string;
 
   /** Get the user-specific localStorage key for sync timestamp */
   private get syncTimestampKey(): string {
@@ -312,6 +313,7 @@ export class SyncEngine {
           pullCursor,
           syncStartedAt,
           pageSize: candidatePageSize,
+          initialPageCount: INITIAL_SYNC_PAGE_COUNT,
           overrides: requestOverrides ?? undefined,
         });
 
@@ -348,7 +350,7 @@ export class SyncEngine {
   /**
    * Bidirectional sync with Cloudflare Worker
    */
-  async syncWithWorker(options?: {
+  async /* NOSONAR - sync orchestration is intentionally centralized; split after batching work stabilizes. */ syncWithWorker(options?: {
     allowDeletes?: boolean;
     pullOnly?: boolean;
     requestOverrides?: SyncRequestOverrides | null;
@@ -413,7 +415,7 @@ export class SyncEngine {
       const outboxItemsToComplete: OutboxItem[] = [];
 
       for (const item of sortedItems) {
-        const adapter = getAdapter(item.tableName as SyncableTableName);
+        const adapter = getAdapter(item.tableName);
 
         if (item.operation.toLowerCase() === "delete") {
           if (!allowDeletes) {
@@ -446,7 +448,7 @@ export class SyncEngine {
           // INSERT/UPDATE
           const localRow = await fetchLocalRowByPrimaryKey(
             this.localDb,
-            item.tableName as SyncableTableName,
+            item.tableName,
             item.rowId
           );
 
@@ -548,6 +550,7 @@ export class SyncEngine {
             this.lastSyncTimestamp || undefined,
             {
               pageSize: INITIAL_SYNC_PAGE_SIZE,
+              initialPageCount: INITIAL_SYNC_PAGE_COUNT,
               overrides: requestOverrides ?? undefined,
             }
           );
@@ -641,7 +644,7 @@ export class SyncEngine {
         const localCountErrorsLogged = new Set<string>();
         if (sqliteDb) {
           for (const [table] of sortedTables) {
-            if (!syncableTables.includes(table as SyncableTableName)) {
+            if (!syncableTables.includes(table)) {
               continue;
             }
             try {

--- a/src/sync/worker-client.test.ts
+++ b/src/sync/worker-client.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WorkerClient } from "./worker-client";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      changes: [],
+      syncedAt: "2024-01-01T00:00:00.000Z",
+    }),
+  });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+function getRequestPayload(): Record<string, unknown> {
+  const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+  expect(init?.body).toBeTypeOf("string");
+  return JSON.parse(init?.body as string) as Record<string, unknown>;
+}
+
+describe("WorkerClient initial pull batching", () => {
+  it("requests batched initial pages for initial sync", async () => {
+    const client = new WorkerClient("token");
+
+    await client.sync([]);
+
+    expect(getRequestPayload().initialPageCount).toBe(16);
+  });
+
+  it("does not send initial page batching hints for incremental sync", async () => {
+    const client = new WorkerClient("token");
+
+    await client.sync([], "2024-01-01T00:00:00.000Z");
+
+    expect(getRequestPayload()).not.toHaveProperty("initialPageCount");
+  });
+});

--- a/src/sync/worker-client.test.ts
+++ b/src/sync/worker-client.test.ts
@@ -3,6 +3,16 @@ import { WorkerClient } from "./worker-client";
 
 const fetchMock = vi.fn();
 
+function createStorage(initial: Record<string, string> = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+  };
+}
+
 beforeEach(() => {
   vi.unstubAllGlobals();
   fetchMock.mockReset();
@@ -45,6 +55,25 @@ describe("WorkerClient initial pull batching", () => {
       location: {
         search: "?ttSyncDiagnostics=1",
       },
+      localStorage: createStorage(),
+    });
+    const client = new WorkerClient("token");
+
+    await client.sync([]);
+
+    expect(getRequestPayload().diagnostics).toBe(true);
+    logSpy.mockRestore();
+  });
+
+  it("requests diagnostics when enabled by consumer localStorage", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.stubGlobal("window", {
+      location: {
+        search: "",
+      },
+      localStorage: createStorage({
+        "tunetrees:sync-baseline-diagnostics": "true",
+      }),
     });
     const client = new WorkerClient("token");
 

--- a/src/sync/worker-client.test.ts
+++ b/src/sync/worker-client.test.ts
@@ -59,10 +59,13 @@ describe("WorkerClient initial pull batching", () => {
     });
     const client = new WorkerClient("token");
 
-    await client.sync([]);
+    try {
+      await client.sync([]);
 
-    expect(getRequestPayload().diagnostics).toBe(true);
-    logSpy.mockRestore();
+      expect(getRequestPayload().diagnostics).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 
   it("requests diagnostics when enabled by consumer localStorage", async () => {
@@ -77,9 +80,12 @@ describe("WorkerClient initial pull batching", () => {
     });
     const client = new WorkerClient("token");
 
-    await client.sync([]);
+    try {
+      await client.sync([]);
 
-    expect(getRequestPayload().diagnostics).toBe(true);
-    logSpy.mockRestore();
+      expect(getRequestPayload().diagnostics).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 });

--- a/src/sync/worker-client.test.ts
+++ b/src/sync/worker-client.test.ts
@@ -4,6 +4,7 @@ import { WorkerClient } from "./worker-client";
 const fetchMock = vi.fn();
 
 beforeEach(() => {
+  vi.unstubAllGlobals();
   fetchMock.mockReset();
   fetchMock.mockResolvedValue({
     ok: true,
@@ -36,5 +37,20 @@ describe("WorkerClient initial pull batching", () => {
     await client.sync([], "2024-01-01T00:00:00.000Z");
 
     expect(getRequestPayload()).not.toHaveProperty("initialPageCount");
+  });
+
+  it("requests diagnostics when enabled by the runtime URL", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.stubGlobal("window", {
+      location: {
+        search: "?ttSyncDiagnostics=1",
+      },
+    });
+    const client = new WorkerClient("token");
+
+    await client.sync([]);
+
+    expect(getRequestPayload().diagnostics).toBe(true);
+    logSpy.mockRestore();
   });
 });

--- a/src/sync/worker-client.ts
+++ b/src/sync/worker-client.ts
@@ -7,13 +7,10 @@ import type {
 
 const WORKER_URL = import.meta.env.VITE_WORKER_URL || "http://localhost:8787";
 const SYNC_DIAGNOSTICS = import.meta.env.VITE_SYNC_DIAGNOSTICS === "true";
+const DEFAULT_INITIAL_PAGE_COUNT = 16;
 
 export class WorkerClient {
-  private token: string;
-
-  constructor(token: string) {
-    this.token = token;
-  }
+  constructor(private readonly token: string) {}
 
   async sync(
     changes: SyncChange[],
@@ -22,10 +19,14 @@ export class WorkerClient {
       pullCursor?: string;
       syncStartedAt?: string;
       pageSize?: number;
+      initialPageCount?: number;
       overrides?: SyncRequestOverrides | null;
     }
   ): Promise<SyncResponse> {
     const overrides = options?.overrides ?? undefined;
+    const initialPageCount =
+      options?.initialPageCount ??
+      (lastSyncAt ? undefined : DEFAULT_INITIAL_PAGE_COUNT);
     const payload: SyncRequest = {
       changes,
       lastSyncAt,
@@ -33,6 +34,7 @@ export class WorkerClient {
       pullCursor: options?.pullCursor,
       syncStartedAt: options?.syncStartedAt,
       pageSize: options?.pageSize,
+      initialPageCount,
       collectionsOverride: overrides?.collectionsOverride,
       rpcParamOverrides: overrides?.rpcParamOverrides,
       pullTables: overrides?.pullTables,

--- a/src/sync/worker-client.ts
+++ b/src/sync/worker-client.ts
@@ -8,6 +8,25 @@ import type {
 const WORKER_URL = import.meta.env.VITE_WORKER_URL || "http://localhost:8787";
 const SYNC_DIAGNOSTICS = import.meta.env.VITE_SYNC_DIAGNOSTICS === "true";
 const DEFAULT_INITIAL_PAGE_COUNT = 16;
+const DIAGNOSTICS_STORAGE_KEY = "oosync:sync-diagnostics";
+const CONSUMER_DIAGNOSTICS_STORAGE_KEYS = [
+  "tunetrees:sync-baseline-diagnostics",
+];
+
+function parseDiagnosticsFlag(value: string | null): boolean | null {
+  if (value === null) {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (["", "1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+  return null;
+}
 
 function isRuntimeDiagnosticsEnabled(): boolean {
   if (SYNC_DIAGNOSTICS) {
@@ -20,7 +39,24 @@ function isRuntimeDiagnosticsEnabled(): boolean {
 
   try {
     const params = new URLSearchParams(window.location.search);
-    return params.get("ttSyncDiagnostics") === "1";
+    const queryFlag =
+      parseDiagnosticsFlag(params.get("ttSyncDiagnostics")) ??
+      parseDiagnosticsFlag(params.get("syncDiagnostics"));
+    if (queryFlag !== null) {
+      window.localStorage.setItem(DIAGNOSTICS_STORAGE_KEY, String(queryFlag));
+      return queryFlag;
+    }
+
+    const storedFlag = parseDiagnosticsFlag(
+      window.localStorage.getItem(DIAGNOSTICS_STORAGE_KEY)
+    );
+    if (storedFlag !== null) {
+      return storedFlag;
+    }
+
+    return CONSUMER_DIAGNOSTICS_STORAGE_KEYS.some(
+      (key) => parseDiagnosticsFlag(window.localStorage.getItem(key)) === true
+    );
   } catch {
     return false;
   }

--- a/src/sync/worker-client.ts
+++ b/src/sync/worker-client.ts
@@ -9,6 +9,23 @@ const WORKER_URL = import.meta.env.VITE_WORKER_URL || "http://localhost:8787";
 const SYNC_DIAGNOSTICS = import.meta.env.VITE_SYNC_DIAGNOSTICS === "true";
 const DEFAULT_INITIAL_PAGE_COUNT = 16;
 
+function isRuntimeDiagnosticsEnabled(): boolean {
+  if (SYNC_DIAGNOSTICS) {
+    return true;
+  }
+
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    const params = new URLSearchParams(window.location.search);
+    return params.get("ttSyncDiagnostics") === "1";
+  } catch {
+    return false;
+  }
+}
+
 export class WorkerClient {
   private readonly authToken: string;
 
@@ -31,6 +48,7 @@ export class WorkerClient {
     const initialPageCount =
       options?.initialPageCount ??
       (lastSyncAt ? undefined : DEFAULT_INITIAL_PAGE_COUNT);
+    const diagnosticsEnabled = isRuntimeDiagnosticsEnabled();
     const payload: SyncRequest = {
       changes,
       lastSyncAt,
@@ -42,6 +60,7 @@ export class WorkerClient {
       collectionsOverride: overrides?.collectionsOverride,
       rpcParamOverrides: overrides?.rpcParamOverrides,
       pullTables: overrides?.pullTables,
+      diagnostics: diagnosticsEnabled ? true : undefined,
     };
 
     const response = await fetch(`${WORKER_URL}/api/sync`, {
@@ -60,11 +79,11 @@ export class WorkerClient {
 
     const json = await response.json();
 
-    if (SYNC_DIAGNOSTICS) {
+    if (diagnosticsEnabled) {
       const total = Array.isArray(json.changes) ? json.changes.length : 0;
       console.log(`[WorkerClientDiag] response totalChanges=${total}`);
       if (Array.isArray(json.debug) && json.debug.length > 0) {
-        for (const line of json.debug.slice(0, 50)) {
+        for (const line of json.debug.slice(0, 200)) {
           console.log(`[WorkerClientDiag] worker: ${String(line)}`);
         }
       }

--- a/src/sync/worker-client.ts
+++ b/src/sync/worker-client.ts
@@ -63,6 +63,17 @@ function isRuntimeDiagnosticsEnabled(): boolean {
   }
 }
 
+function isSyncResponse(value: unknown): value is SyncResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    Array.isArray(candidate.changes) && typeof candidate.syncedAt === "string"
+  );
+}
+
 export class WorkerClient {
   private readonly authToken: string;
 
@@ -114,7 +125,10 @@ export class WorkerClient {
       throw new Error(`Sync failed: ${response.status} ${text}`);
     }
 
-    const json = await response.json();
+    const json: unknown = await response.json();
+    if (!isSyncResponse(json)) {
+      throw new Error("Sync failed: invalid worker response");
+    }
 
     if (diagnosticsEnabled) {
       const total = Array.isArray(json.changes) ? json.changes.length : 0;

--- a/src/sync/worker-client.ts
+++ b/src/sync/worker-client.ts
@@ -33,29 +33,30 @@ function isRuntimeDiagnosticsEnabled(): boolean {
     return true;
   }
 
-  if (typeof window === "undefined") {
+  if (globalThis.window === undefined) {
     return false;
   }
 
   try {
-    const params = new URLSearchParams(window.location.search);
+    const { localStorage, location } = globalThis.window;
+    const params = new URLSearchParams(location.search);
     const queryFlag =
       parseDiagnosticsFlag(params.get("ttSyncDiagnostics")) ??
       parseDiagnosticsFlag(params.get("syncDiagnostics"));
     if (queryFlag !== null) {
-      window.localStorage.setItem(DIAGNOSTICS_STORAGE_KEY, String(queryFlag));
+      localStorage.setItem(DIAGNOSTICS_STORAGE_KEY, String(queryFlag));
       return queryFlag;
     }
 
     const storedFlag = parseDiagnosticsFlag(
-      window.localStorage.getItem(DIAGNOSTICS_STORAGE_KEY)
+      localStorage.getItem(DIAGNOSTICS_STORAGE_KEY)
     );
     if (storedFlag !== null) {
       return storedFlag;
     }
 
     return CONSUMER_DIAGNOSTICS_STORAGE_KEYS.some(
-      (key) => parseDiagnosticsFlag(window.localStorage.getItem(key)) === true
+      (key) => parseDiagnosticsFlag(localStorage.getItem(key)) === true
     );
   } catch {
     return false;

--- a/src/sync/worker-client.ts
+++ b/src/sync/worker-client.ts
@@ -10,7 +10,11 @@ const SYNC_DIAGNOSTICS = import.meta.env.VITE_SYNC_DIAGNOSTICS === "true";
 const DEFAULT_INITIAL_PAGE_COUNT = 16;
 
 export class WorkerClient {
-  constructor(private readonly token: string) {}
+  private readonly authToken: string;
+
+  constructor(token: string) {
+    this.authToken = token;
+  }
 
   async sync(
     changes: SyncChange[],
@@ -44,7 +48,7 @@ export class WorkerClient {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${this.token}`,
+        Authorization: `Bearer ${this.authToken}`,
       },
       body: JSON.stringify(payload),
     });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -48,7 +48,10 @@ function notInitialized(name: string): never {
 
 let schemaTables: SchemaTables | null = null;
 let SYNCABLE_TABLES: readonly string[] = [];
-let TABLE_REGISTRY: Record<string, unknown> = {};
+let TABLE_REGISTRY: Record<
+  string,
+  { relationKind?: "table" | "view" | "materialized_view" | string }
+> = {};
 
 let getPrimaryKey: (tableName: string) => string | string[] = () =>
   notInitialized("getPrimaryKey");
@@ -348,6 +351,54 @@ interface SyncContext {
   diagnosticsEnabled: boolean;
   perfDebugEnabled: boolean;
   perfMinDurationMs: number;
+}
+
+interface InitialPullPage {
+  changes: SyncChange[];
+  diagnostics: string[];
+}
+
+function getRelationKind(tableName: string): string {
+  return TABLE_REGISTRY[tableName]?.relationKind ?? "relation";
+}
+
+function estimatePayloadBytes(changes: SyncChange[]): number {
+  return estimateJsonBytes(changes);
+}
+
+function estimateJsonBytes(value: unknown): number {
+  try {
+    return new TextEncoder().encode(JSON.stringify(value)).length;
+  } catch {
+    return -1;
+  }
+}
+
+function createInitialPageDiagnostics(params: {
+  tableName: string;
+  ruleKind: string;
+  offset: number;
+  limit: number;
+  rows: number;
+  queryDurationMs: number;
+  transformDurationMs: number;
+  totalDurationMs: number;
+  payloadBytes: number;
+}): string {
+  return [
+    "[WorkerSyncDiag]",
+    "initialPage",
+    `relation=${params.tableName}`,
+    `kind=${getRelationKind(params.tableName)}`,
+    `rule=${params.ruleKind}`,
+    `offset=${params.offset}`,
+    `limit=${params.limit}`,
+    `rows=${params.rows}`,
+    `queryMs=${params.queryDurationMs}`,
+    `transformMs=${params.transformDurationMs}`,
+    `payloadBytes=${params.payloadBytes}`,
+    `totalMs=${params.totalDurationMs}`,
+  ].join(" ");
 }
 
 interface InitialSyncCursorV1 {
@@ -1094,13 +1145,14 @@ async function fetchTableForInitialSyncPage(
   syncStartedAt: string,
   offset: number,
   limit: number
-): Promise<SyncChange[]> {
+): Promise<InitialPullPage> {
+  const startedAt = Date.now();
   const table = getSchemaTables()[tableName];
-  if (!table) return [];
+  if (!table) return { changes: [], diagnostics: [] };
 
   const t = table;
   const meta = TABLE_REGISTRY[tableName];
-  if (!meta) return [];
+  if (!meta) return { changes: [], diagnostics: [] };
 
   // Check if table uses RPC for filtering
   const rule = getPullRule(tableName);
@@ -1114,12 +1166,15 @@ async function fetchTableForInitialSyncPage(
       pageOffset: offset,
     });
 
+    const queryStartedAt = Date.now();
     const rows = await fetchViaRPC(tx, rule.functionName, rpcParams);
+    const queryDurationMs = Date.now() - queryStartedAt;
 
     debug.log(
       `[PULL:INITIAL] ${tableName} (RPC): fetched ${rows.length} rows via ${rule.functionName}`
     );
 
+    const transformStartedAt = Date.now();
     const changes: SyncChange[] = [];
     for (const row of rows) {
       // Apply adapter transformation: Postgres (snake_case) -> Client (camelCase)
@@ -1127,7 +1182,24 @@ async function fetchTableForInitialSyncPage(
       const rowId = extractRowId(tableName, transformed, t);
       changes.push(rowToSyncChange(tableName, rowId, transformed));
     }
-    return changes;
+    const transformDurationMs = Date.now() - transformStartedAt;
+    const totalDurationMs = Date.now() - startedAt;
+    return {
+      changes,
+      diagnostics: [
+        createInitialPageDiagnostics({
+          tableName,
+          ruleKind: `rpc:${rule.functionName}`,
+          offset,
+          limit,
+          rows: changes.length,
+          queryDurationMs,
+          transformDurationMs,
+          totalDurationMs,
+          payloadBytes: estimatePayloadBytes(changes),
+        }),
+      ],
+    };
   }
 
   // Standard SQL-based fetch (non-RPC tables)
@@ -1141,7 +1213,22 @@ async function fetchTableForInitialSyncPage(
     debug.log(
       `[PULL:INITIAL] Skipping ${tableName} (no matching rows for user)`
     );
-    return [];
+    return {
+      changes: [],
+      diagnostics: [
+        createInitialPageDiagnostics({
+          tableName,
+          ruleKind: "skipped:no-filter-match",
+          offset,
+          limit,
+          rows: 0,
+          queryDurationMs: 0,
+          transformDurationMs: 0,
+          totalDurationMs: Date.now() - startedAt,
+          payloadBytes: 0,
+        }),
+      ],
+    };
   }
 
   const whereConditions: unknown[] = [...conditions];
@@ -1158,19 +1245,39 @@ async function fetchTableForInitialSyncPage(
     query = query.where(and(...whereConditions));
   }
 
+  const queryStartedAt = Date.now();
   const rows = await query.limit(limit).offset(offset);
+  const queryDurationMs = Date.now() - queryStartedAt;
 
   debug.log(
     `[PULL:INITIAL] ${tableName}: fetched page rows=${rows.length} offset=${offset} limit=${limit}`
   );
 
+  const transformStartedAt = Date.now();
   const changes: SyncChange[] = [];
   for (const row of rows) {
     const r = row;
     const rowId = extractRowId(tableName, r, t);
     changes.push(rowToSyncChange(tableName, rowId, r));
   }
-  return changes;
+  const transformDurationMs = Date.now() - transformStartedAt;
+  const totalDurationMs = Date.now() - startedAt;
+  return {
+    changes,
+    diagnostics: [
+      createInitialPageDiagnostics({
+        tableName,
+        ruleKind: rule?.kind ?? "default",
+        offset,
+        limit,
+        rows: changes.length,
+        queryDurationMs,
+        transformDurationMs,
+        totalDurationMs,
+        payloadBytes: estimatePayloadBytes(changes),
+      }),
+    ],
+  };
 }
 
 async function processInitialSyncPaged(
@@ -1210,7 +1317,7 @@ async function processInitialSyncPaged(
       continue;
     }
     const pageStartedAt = Date.now();
-    const changes = await fetchTableForInitialSyncPage(
+    const page = await fetchTableForInitialSyncPage(
       tx,
       tableName,
       ctx,
@@ -1218,17 +1325,16 @@ async function processInitialSyncPaged(
       offset,
       pageSize
     );
+    const { changes } = page;
     const pageDurationMs = Date.now() - pageStartedAt;
     perfLogDuration(
       ctx.perfDebugEnabled,
       ctx.perfMinDurationMs,
       pageDurationMs,
-      `initial.page table=${tableName} offset=${offset} limit=${pageSize} rows=${changes.length}`
+      `initial.page relation=${tableName} kind=${getRelationKind(tableName)} offset=${offset} limit=${pageSize} rows=${changes.length}`
     );
     if (ctx.diagnosticsEnabled) {
-      diagnostics.push(
-        `[WorkerSyncDiag] initialPage table=${tableName} offset=${offset} limit=${pageSize} rows=${changes.length} durationMs=${pageDurationMs}`
-      );
+      diagnostics.push(...page.diagnostics);
     }
 
     if (changes.length === 0) {
@@ -1479,7 +1585,7 @@ function addResponseDiagnostics(
     .map(([tableName, count]) => `${tableName}:${count}`)
     .join(",");
   diag.push(
-    `[WorkerSyncDiag] changesOut=${responseChanges.length} nextCursor=${nextCursor ? "yes" : "no"} syncStartedAt=${syncStartedAt ?? "null"} topTables=${top || "(none)"}`
+    `[WorkerSyncDiag] changesOut=${responseChanges.length} payloadBytes=${estimatePayloadBytes(responseChanges)} nextCursor=${nextCursor ? "yes" : "no"} syncStartedAt=${syncStartedAt ?? "null"} topRelations=${top || "(none)"}`
   );
 }
 
@@ -1534,7 +1640,8 @@ async function loadCollectionsForSync(
   authUserId: string,
   payload: SyncRequest,
   perfDebugEnabled: boolean,
-  perfMinDurationMs: number
+  perfMinDurationMs: number,
+  diag?: string[]
 ): Promise<Record<string, Set<string>>> {
   const collectionsStartedAt = Date.now();
   const collections = await loadUserCollections({
@@ -1548,7 +1655,15 @@ async function loadCollectionsForSync(
     Date.now() - collectionsStartedAt,
     "sync.collections"
   );
+  diag?.push(
+    `[WorkerSyncDiag] collections loadMs=${Date.now() - collectionsStartedAt}`
+  );
   applyCollectionOverrides(collections, payload.collectionsOverride);
+  if (diag && payload.collectionsOverride) {
+    diag.push(
+      `[WorkerSyncDiag] collections overrideKeys=${Object.keys(payload.collectionsOverride).join(",") || "(none)"}`
+    );
+  }
   return collections;
 }
 
@@ -1616,7 +1731,8 @@ async function runSyncTransaction(params: {
     authUserId,
     params.payload,
     params.perfDebugEnabled,
-    params.perfMinDurationMs
+    params.perfMinDurationMs,
+    params.diagnosticsEnabled ? params.diag : undefined
   );
   const pullTables = buildPullTables(params.payload.pullTables);
   logPullTableMode(pullTables);
@@ -1649,7 +1765,8 @@ async function runSyncTransaction(params: {
     authUserId,
     params.payload,
     params.perfDebugEnabled,
-    params.perfMinDurationMs
+    params.perfMinDurationMs,
+    params.diagnosticsEnabled ? params.diag : undefined
   );
 
   const result = await processPullForSync(
@@ -1674,6 +1791,11 @@ async function runSyncTransaction(params: {
 
   // NO GARBAGE COLLECTION NEEDED!
   // sync_change_log now has at most ~20 rows (one per table)
+  if (params.diagnosticsEnabled) {
+    params.diag.push(
+      `[WorkerSyncDiag] transaction totalMs=${Date.now() - txStartedAt}`
+    );
+  }
   perfLogDuration(
     params.perfDebugEnabled,
     params.perfMinDurationMs,
@@ -1690,10 +1812,11 @@ async function handleSync(
   userId: string,
   diagnosticsEnabled: boolean,
   perfDebugEnabled: boolean,
-  perfMinDurationMs: number
+  perfMinDurationMs: number,
+  initialDiagnostics: string[] = []
 ): Promise<SyncResponse> {
   const now = new Date().toISOString();
-  const diag: string[] = [];
+  const diag: string[] = [...initialDiagnostics];
   let responseChanges: SyncChange[] = [];
   let nextCursor: string | undefined;
   let syncStartedAt: string | undefined;
@@ -1741,6 +1864,9 @@ async function handleSync(
     Date.now() - syncStartedAtMs,
     `sync.complete type=${syncType} changesOut=${responseChanges.length} total`
   );
+  if (diagnosticsEnabled) {
+    diag.push(`[WorkerSyncDiag] sync totalMs=${Date.now() - syncStartedAtMs}`);
+  }
 
   return {
     changes: responseChanges,
@@ -1831,10 +1957,11 @@ async function fetch(request: Request, env: Env): Promise<Response> {
         env.SUPABASE_JWT_SECRET,
         env.SUPABASE_URL
       );
+      const authDurationMs = Date.now() - authStartedAt;
       perfLogDuration(
         perfDebugEnabled,
         perfMinDurationMs,
-        Date.now() - authStartedAt,
+        authDurationMs,
         `http.sync.auth authorized=${userId ? "yes" : "no"}`
       );
       if (!userId) {
@@ -1842,17 +1969,24 @@ async function fetch(request: Request, env: Env): Promise<Response> {
         return errorResponse("Unauthorized", corsHeaders, 401);
       }
 
-      const diagnosticsEnabled =
+      const payloadStartedAt = Date.now();
+      const payload: SyncRequest = await request.json();
+      const payloadParseDurationMs = Date.now() - payloadStartedAt;
+      const diagnosticsAllowed =
         env.SYNC_DIAGNOSTICS === "true" &&
         (!env.SYNC_DIAGNOSTICS_USER_ID ||
           env.SYNC_DIAGNOSTICS_USER_ID === userId);
-
-      const payloadStartedAt = Date.now();
-      const payload: SyncRequest = await request.json();
+      const diagnosticsEnabled =
+        diagnosticsAllowed && payload.diagnostics === true;
+      const requestDiagnostics = diagnosticsEnabled
+        ? [
+            `[WorkerSyncDiag] http authMs=${authDurationMs} payloadParseMs=${payloadParseDurationMs}`,
+          ]
+        : [];
       perfLogDuration(
         perfDebugEnabled,
         perfMinDurationMs,
-        Date.now() - payloadStartedAt,
+        payloadParseDurationMs,
         `http.sync.payload.parse changesIn=${payload.changes.length}`
       );
 
@@ -1861,14 +1995,21 @@ async function fetch(request: Request, env: Env): Promise<Response> {
         debug.log(`[HTTP] Sync request parsed, calling handleSync`);
         const createDbStartedAt = Date.now();
         const { db, close } = createDb(env);
+        const dbCreateDurationMs = Date.now() - createDbStartedAt;
+        if (diagnosticsEnabled) {
+          requestDiagnostics.push(
+            `[WorkerSyncDiag] http dbCreateMs=${dbCreateDurationMs}`
+          );
+        }
         perfLogDuration(
           perfDebugEnabled,
           perfMinDurationMs,
-          Date.now() - createDbStartedAt,
+          dbCreateDurationMs,
           "http.sync.db.create"
         );
 
         const handleSyncStartedAt = Date.now();
+        let dbCloseDurationMs: number | undefined;
         const response = await (async () => {
           try {
             return await handleSync(
@@ -1877,19 +2018,30 @@ async function fetch(request: Request, env: Env): Promise<Response> {
               userId,
               diagnosticsEnabled,
               perfDebugEnabled,
-              perfMinDurationMs
+              perfMinDurationMs,
+              requestDiagnostics
             );
           } finally {
             const closeStartedAt = Date.now();
             await close();
+            dbCloseDurationMs = Date.now() - closeStartedAt;
             perfLogDuration(
               perfDebugEnabled,
               perfMinDurationMs,
-              Date.now() - closeStartedAt,
+              dbCloseDurationMs,
               "http.sync.db.close"
             );
           }
         })();
+        if (diagnosticsEnabled) {
+          response.debug ??= [];
+          response.debug.push(
+            `[WorkerSyncDiag] http dbCloseMs=${dbCloseDurationMs ?? "unknown"}`
+          );
+          response.debug.push(
+            `[WorkerSyncDiag] http handleMs=${Date.now() - handleSyncStartedAt} requestTotalMs=${Date.now() - requestStartedAt} responseBytesApprox=${estimateJsonBytes(response)}`
+          );
+        }
         perfLogDuration(
           perfDebugEnabled,
           perfMinDurationMs,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -68,6 +68,7 @@ let loadUserCollections: (params: {
   tx: WorkerTransaction;
   userId: string;
   tables: SchemaTables;
+  collectionNames?: ReadonlySet<string>;
 }) => Promise<Record<string, Set<string>>> = async () =>
   notInitialized("loadUserCollections");
 let minimalPayload: (
@@ -152,6 +153,10 @@ function isPostgresJsErrorLike(error: unknown): error is PostgresJsErrorLike {
 
 function toOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function sortStrings(values: Iterable<string>): string[] {
+  return [...values].sort((a, b) => a.localeCompare(b));
 }
 
 function getErrorCause(error: unknown): unknown {
@@ -333,6 +338,8 @@ export interface Env {
   SYNC_DIAGNOSTICS?: string;
   /** Optional: only emit diagnostics when JWT sub matches this value. */
   SYNC_DIAGNOSTICS_USER_ID?: string;
+  /** Optional HMAC secret for signed initial-sync cursors. */
+  OOSYNC_CURSOR_SECRET?: string;
 }
 
 /** Context passed through sync operations */
@@ -348,6 +355,8 @@ interface SyncContext {
   diagnosticsEnabled: boolean;
   perfDebugEnabled: boolean;
   perfMinDurationMs: number;
+  cursorSecret?: string;
+  initialCursor?: DecodedInitialSyncCursor;
 }
 
 interface InitialPullPage {
@@ -504,6 +513,26 @@ interface InitialSyncCursorV1 {
   syncStartedAt: string;
 }
 
+interface InitialSyncCursorPayloadV2 {
+  v: 2;
+  userId: string;
+  tableIndex: number;
+  offset: number;
+  syncStartedAt: string;
+  collections: Record<string, string[]>;
+}
+
+interface InitialSyncCursorV2 extends InitialSyncCursorPayloadV2 {
+  sig: string;
+}
+
+interface DecodedInitialSyncCursor {
+  tableIndex: number;
+  offset: number;
+  syncStartedAt: string;
+  collections?: Record<string, Set<string>>;
+}
+
 interface InitialSyncPageState {
   tableIndex: number;
   offset: number;
@@ -514,24 +543,50 @@ interface InitialSyncPageBudget {
   pageCount: number;
 }
 
-function encodeCursor(cursor: InitialSyncCursorV1): string {
-  return btoa(JSON.stringify(cursor));
+function decodeBase64Url(value: string): Uint8Array {
+  const normalized = value.replaceAll("-", "+").replaceAll("_", "/");
+  const padded = normalized.padEnd(
+    normalized.length + ((4 - (normalized.length % 4)) % 4),
+    "="
+  );
+  const binary = atob(padded);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    out[i] = binary.codePointAt(i) ?? 0;
+  }
+  return out;
 }
 
-function decodeCursor(raw: string): InitialSyncCursorV1 {
+function encodeBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCodePoint(byte);
+  }
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}
+
+function encodeJsonCursor(value: unknown): string {
+  return btoa(JSON.stringify(value));
+}
+
+function decodeJsonCursor(raw: string): unknown {
   let parsed: unknown;
   try {
     parsed = JSON.parse(atob(raw));
   } catch {
     throw new Error("Invalid pullCursor");
   }
+  return parsed;
+}
 
-  if (!parsed || typeof parsed !== "object") {
-    throw new Error("Invalid pullCursor");
-  }
-
-  const obj = parsed as Record<string, unknown>;
-  if (obj.v !== 1) throw new Error("Unsupported pullCursor version");
+function validateCursorFields(obj: Record<string, unknown>): {
+  tableIndex: number;
+  offset: number;
+  syncStartedAt: string;
+} {
   const tableIndex = Number(obj.tableIndex);
   const offset = Number(obj.offset);
   const syncStartedAt = String(obj.syncStartedAt);
@@ -546,23 +601,166 @@ function decodeCursor(raw: string): InitialSyncCursorV1 {
     throw new Error("Invalid pullCursor.syncStartedAt");
   }
 
-  return { v: 1, tableIndex, offset, syncStartedAt };
+  return { tableIndex, offset, syncStartedAt };
 }
 
-function encodeNextInitialSyncCursor(
+function decodeCursorCollections(value: unknown): Record<string, Set<string>> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  const out: Record<string, Set<string>> = {};
+  for (const [name, rawValues] of Object.entries(value)) {
+    if (!Array.isArray(rawValues)) {
+      continue;
+    }
+    out[name] = new Set(rawValues.map(String));
+  }
+  return out;
+}
+
+function encodeCursorCollections(
+  collections: Record<string, Set<string>>,
+  collectionNames: ReadonlySet<string>
+): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const name of [...collectionNames].sort((a, b) => a.localeCompare(b))) {
+    const collection = collections[name];
+    if (!collection) {
+      continue;
+    }
+    out[name] = [...collection].sort((a, b) => a.localeCompare(b));
+  }
+  return out;
+}
+
+async function signCursorPayload(
+  payload: InitialSyncCursorPayloadV2,
+  secret: string
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(JSON.stringify(payload))
+  );
+  return encodeBase64Url(new Uint8Array(signature));
+}
+
+async function verifyCursorSignature(
+  cursor: InitialSyncCursorV2,
+  secret: string
+): Promise<boolean> {
+  const { sig, ...payload } = cursor;
+  const expected = await signCursorPayload(payload, secret);
+  const actualBytes = decodeBase64Url(sig);
+  const expectedBytes = decodeBase64Url(expected);
+  if (actualBytes.length !== expectedBytes.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < actualBytes.length; i += 1) {
+    diff |= actualBytes[i] ^ expectedBytes[i];
+  }
+  return diff === 0;
+}
+
+async function encodeCursor(
+  cursor: DecodedInitialSyncCursor,
+  userId: string,
+  collections: Record<string, Set<string>>,
+  collectionNames: ReadonlySet<string>,
+  cursorSecret: string | undefined
+): Promise<string> {
+  if (!cursorSecret || collectionNames.size === 0) {
+    return encodeJsonCursor({
+      v: 1,
+      tableIndex: cursor.tableIndex,
+      offset: cursor.offset,
+      syncStartedAt: cursor.syncStartedAt,
+    } satisfies InitialSyncCursorV1);
+  }
+
+  const payload: InitialSyncCursorPayloadV2 = {
+    v: 2,
+    userId,
+    tableIndex: cursor.tableIndex,
+    offset: cursor.offset,
+    syncStartedAt: cursor.syncStartedAt,
+    collections: encodeCursorCollections(collections, collectionNames),
+  };
+  return encodeJsonCursor({
+    ...payload,
+    sig: await signCursorPayload(payload, cursorSecret),
+  } satisfies InitialSyncCursorV2);
+}
+
+async function decodeCursor(
+  raw: string,
+  userId: string,
+  cursorSecret: string | undefined
+): Promise<DecodedInitialSyncCursor> {
+  const parsed = decodeJsonCursor(raw);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new TypeError("Invalid pullCursor");
+  }
+  const obj = parsed as Record<string, unknown>;
+  const fields = validateCursorFields(obj);
+
+  if (obj.v === 1) {
+    return fields;
+  }
+
+  if (obj.v !== 2) {
+    throw new TypeError("Unsupported pullCursor version");
+  }
+  if (!cursorSecret) {
+    throw new Error("Signed pullCursor requires cursor secret");
+  }
+  if (typeof obj.sig !== "string") {
+    throw new TypeError("Invalid pullCursor signature");
+  }
+  const cursor = obj as unknown as InitialSyncCursorV2;
+  if (!(await verifyCursorSignature(cursor, cursorSecret))) {
+    throw new Error("Invalid pullCursor signature");
+  }
+  if (cursor.userId !== userId) {
+    throw new Error("Invalid pullCursor user");
+  }
+  return {
+    ...fields,
+    collections: decodeCursorCollections(obj.collections),
+  };
+}
+
+async function encodeNextInitialSyncCursor(
   state: InitialSyncPageState,
-  syncStartedAt: string
-): string | undefined {
+  syncStartedAt: string,
+  userId: string,
+  collections: Record<string, Set<string>>,
+  collectionNames: ReadonlySet<string>,
+  cursorSecret: string | undefined
+): Promise<string | undefined> {
   if (state.tableIndex >= SYNCABLE_TABLES.length) {
     return undefined;
   }
 
-  return encodeCursor({
-    v: 1,
-    tableIndex: state.tableIndex,
-    offset: state.offset,
-    syncStartedAt,
-  });
+  return await encodeCursor(
+    {
+      tableIndex: state.tableIndex,
+      offset: state.offset,
+      syncStartedAt,
+    },
+    userId,
+    collections,
+    collectionNames,
+    cursorSecret
+  );
 }
 
 function normalizePositiveIntegerHint(
@@ -588,11 +786,11 @@ function getInitialSyncPageBudget(
 }
 
 function getInitialSyncStartState(params: {
-  cursorRaw?: string;
+  initialCursor?: DecodedInitialSyncCursor;
   syncStartedAtHint?: string;
   now: string;
 }): InitialSyncPageState & { syncStartedAt: string } {
-  if (!params.cursorRaw) {
+  if (!params.initialCursor) {
     return {
       tableIndex: 0,
       offset: 0,
@@ -600,11 +798,10 @@ function getInitialSyncStartState(params: {
     };
   }
 
-  const cursor = decodeCursor(params.cursorRaw);
   return {
-    tableIndex: cursor.tableIndex,
-    offset: cursor.offset,
-    syncStartedAt: cursor.syncStartedAt,
+    tableIndex: params.initialCursor.tableIndex,
+    offset: params.initialCursor.offset,
+    syncStartedAt: params.initialCursor.syncStartedAt,
   };
 }
 
@@ -1376,10 +1573,49 @@ async function fetchTableForInitialSyncPage(
   };
 }
 
+async function collectInitialSyncPage(params: {
+  tx: Transaction;
+  ctx: SyncContext;
+  tableName: string;
+  syncStartedAt: string;
+  offset: number;
+  pageSize: number;
+  diagnostics: string[];
+  timings: InitialPageTiming[];
+  timingAggregates: Map<string, InitialTimingAggregate>;
+}): Promise<InitialPullPage> {
+  const pageStartedAt = Date.now();
+  const page = await fetchTableForInitialSyncPage(
+    params.tx,
+    params.tableName,
+    params.ctx,
+    params.syncStartedAt,
+    params.offset,
+    params.pageSize
+  );
+  const { changes } = page;
+  const pageDurationMs = Date.now() - pageStartedAt;
+  perfLogDuration(
+    params.ctx.perfDebugEnabled,
+    params.ctx.perfMinDurationMs,
+    pageDurationMs,
+    `initial.page relation=${params.tableName} kind=${getRelationKind(params.tableName)} offset=${params.offset} limit=${params.pageSize} rows=${changes.length}`
+  );
+  if (!params.ctx.diagnosticsEnabled) {
+    return page;
+  }
+
+  params.diagnostics.push(...page.diagnostics);
+  if (page.timing) {
+    params.timings.push(page.timing);
+    addInitialTimingAggregate(params.timingAggregates, page.timing);
+  }
+  return page;
+}
+
 async function processInitialSyncPaged(
   tx: Transaction,
   ctx: SyncContext,
-  cursorRaw: string | undefined,
   syncStartedAtHint: string | undefined,
   pageSizeHint: number | undefined,
   pageCountHint: number | undefined
@@ -1394,7 +1630,7 @@ async function processInitialSyncPaged(
     pageCountHint
   );
   const startState = getInitialSyncStartState({
-    cursorRaw,
+    initialCursor: ctx.initialCursor,
     syncStartedAtHint,
     now: ctx.now,
   });
@@ -1414,30 +1650,18 @@ async function processInitialSyncPaged(
       offset = 0;
       continue;
     }
-    const pageStartedAt = Date.now();
-    const page = await fetchTableForInitialSyncPage(
+    const page = await collectInitialSyncPage({
       tx,
-      tableName,
       ctx,
+      tableName,
       syncStartedAt,
       offset,
-      pageSize
-    );
+      pageSize,
+      diagnostics,
+      timings,
+      timingAggregates,
+    });
     const { changes } = page;
-    const pageDurationMs = Date.now() - pageStartedAt;
-    perfLogDuration(
-      ctx.perfDebugEnabled,
-      ctx.perfMinDurationMs,
-      pageDurationMs,
-      `initial.page relation=${tableName} kind=${getRelationKind(tableName)} offset=${offset} limit=${pageSize} rows=${changes.length}`
-    );
-    if (ctx.diagnosticsEnabled) {
-      diagnostics.push(...page.diagnostics);
-      if (page.timing) {
-        timings.push(page.timing);
-        addInitialTimingAggregate(timingAggregates, page.timing);
-      }
-    }
 
     if (changes.length === 0) {
       // Either table is empty / skipped OR we've paged past the end.
@@ -1472,9 +1696,13 @@ async function processInitialSyncPaged(
   return {
     changes: allChanges,
     syncStartedAt,
-    nextCursor: encodeNextInitialSyncCursor(
+    nextCursor: await encodeNextInitialSyncCursor(
       { tableIndex, offset },
-      syncStartedAt
+      syncStartedAt,
+      ctx.authUserId,
+      ctx.collections,
+      getRequiredCollectionNames(ctx.pullTables),
+      ctx.cursorSecret
     ),
     diagnostics,
   };
@@ -1656,26 +1884,26 @@ interface SyncTransactionResult {
   diagnostics?: string[];
 }
 
-function getCursorSummary(payload: SyncRequest): string {
-  if (!payload.pullCursor) {
+function getCursorSummary(
+  cursor: DecodedInitialSyncCursor | undefined
+): string {
+  if (!cursor) {
     return "cursor=none";
   }
 
-  try {
-    const cursor = decodeCursor(payload.pullCursor);
-    return `tableIndex=${cursor.tableIndex} offset=${cursor.offset}`;
-  } catch {
-    return "cursor=invalid";
-  }
+  const collectionNames = Object.keys(cursor.collections ?? {});
+  const sortedCollectionNames = sortStrings(collectionNames);
+  return `tableIndex=${cursor.tableIndex} offset=${cursor.offset} cursorCollections=${sortedCollectionNames.join(",") || "(none)"}`;
 }
 
 function addStartDiagnostics(
   diag: string[],
   payload: SyncRequest,
-  syncType: SyncType
+  syncType: SyncType,
+  initialCursor: DecodedInitialSyncCursor | undefined
 ): void {
   diag.push(
-    `[WorkerSyncDiag] type=${syncType} changesIn=${payload.changes.length} lastSyncAt=${payload.lastSyncAt ?? "null"} pageSize=${payload.pageSize ?? "null"} initialPageCount=${payload.initialPageCount ?? "null"} ${getCursorSummary(payload)}`
+    `[WorkerSyncDiag] type=${syncType} changesIn=${payload.changes.length} lastSyncAt=${payload.lastSyncAt ?? "null"} pageSize=${payload.pageSize ?? "null"} initialPageCount=${payload.initialPageCount ?? "null"} ${getCursorSummary(initialCursor)}`
   );
 }
 
@@ -1734,6 +1962,82 @@ function buildPullTables(
   return pullTables ? new Set(pullTables.map(String)) : undefined;
 }
 
+function addRuleCollectionNames(
+  rule: PullTableRule | undefined,
+  collectionNames: Set<string>
+): void {
+  if (!rule) {
+    return;
+  }
+
+  if (rule.kind === "inCollection") {
+    collectionNames.add(rule.collection);
+    return;
+  }
+
+  if (rule.kind === "compound") {
+    for (const nestedRule of rule.rules) {
+      addRuleCollectionNames(nestedRule, collectionNames);
+    }
+    return;
+  }
+
+  if (rule.kind === "rpc") {
+    for (const binding of Object.values(rule.paramMap)) {
+      if (binding.source === "collection") {
+        collectionNames.add(binding.collection);
+      }
+    }
+  }
+}
+
+function getPullTableNames(pullTables: Set<string> | undefined): string[] {
+  if (!pullTables) {
+    return [...SYNCABLE_TABLES];
+  }
+  return SYNCABLE_TABLES.filter((tableName) => pullTables.has(tableName));
+}
+
+function getRequiredCollectionNames(
+  pullTables: Set<string> | undefined
+): Set<string> {
+  const collectionNames = new Set<string>();
+  for (const tableName of getPullTableNames(pullTables)) {
+    addRuleCollectionNames(getPullRule(tableName), collectionNames);
+  }
+  return collectionNames;
+}
+
+function cloneCollectionMap(
+  collections: Record<string, Set<string>> | undefined
+): Record<string, Set<string>> {
+  const out: Record<string, Set<string>> = {};
+  if (!collections) {
+    return out;
+  }
+  for (const [name, values] of Object.entries(collections)) {
+    out[name] = new Set(values);
+  }
+  return out;
+}
+
+function getMissingCollectionNames(
+  requiredCollectionNames: ReadonlySet<string>,
+  collections: Record<string, Set<string>>,
+  overrides: SyncRequest["collectionsOverride"]
+): Set<string> {
+  const missing = new Set<string>();
+  for (const name of requiredCollectionNames) {
+    if (overrides && Object.hasOwn(overrides, name)) {
+      continue;
+    }
+    if (!collections[name]) {
+      missing.add(name);
+    }
+  }
+  return missing;
+}
+
 function logPullTableMode(pullTables: Set<string> | undefined): void {
   if (pullTables) {
     debug.log(
@@ -1745,33 +2049,51 @@ function logPullTableMode(pullTables: Set<string> | undefined): void {
   debug.log("[Worker] 🚨 No pullTables override - syncing all tables");
 }
 
-async function loadCollectionsForSync(
-  tx: Transaction,
-  authUserId: string,
-  payload: SyncRequest,
-  perfDebugEnabled: boolean,
-  perfMinDurationMs: number,
-  diag?: string[]
-): Promise<Record<string, Set<string>>> {
+async function loadCollectionsForSync(params: {
+  tx: Transaction;
+  authUserId: string;
+  payload: SyncRequest;
+  requiredCollectionNames: ReadonlySet<string>;
+  carriedCollections?: Record<string, Set<string>>;
+  perfDebugEnabled: boolean;
+  perfMinDurationMs: number;
+  diag?: string[];
+}): Promise<Record<string, Set<string>>> {
   const collectionsStartedAt = Date.now();
-  const collections = await loadUserCollections({
-    tx,
-    userId: authUserId,
+  const collections = cloneCollectionMap(params.carriedCollections);
+  const missingCollectionNames = getMissingCollectionNames(
+    params.requiredCollectionNames,
+    collections,
+    params.payload.collectionsOverride
+  );
+  const loadedCollections = await loadUserCollections({
+    tx: params.tx,
+    userId: params.authUserId,
     tables: getSchemaTables(),
+    collectionNames: missingCollectionNames,
   });
+  Object.assign(collections, loadedCollections);
   perfLogDuration(
-    perfDebugEnabled,
-    perfMinDurationMs,
+    params.perfDebugEnabled,
+    params.perfMinDurationMs,
     Date.now() - collectionsStartedAt,
     "sync.collections"
   );
-  diag?.push(
-    `[WorkerSyncDiag] collections loadMs=${Date.now() - collectionsStartedAt}`
+  const requiredNames = sortStrings(params.requiredCollectionNames).join(",");
+  const carriedNames = sortStrings(
+    Object.keys(params.carriedCollections ?? {})
+  ).join(",");
+  const loadedNames = sortStrings(missingCollectionNames).join(",");
+  params.diag?.push(
+    `[WorkerSyncDiag] collections loadMs=${Date.now() - collectionsStartedAt} required=${requiredNames || "(none)"} carried=${carriedNames || "(none)"} loaded=${loadedNames || "(none)"}`
   );
-  applyCollectionOverrides(collections, payload.collectionsOverride);
-  if (diag && payload.collectionsOverride) {
-    diag.push(
-      `[WorkerSyncDiag] collections overrideKeys=${Object.keys(payload.collectionsOverride).join(",") || "(none)"}`
+  applyCollectionOverrides(collections, params.payload.collectionsOverride);
+  if (params.diag && params.payload.collectionsOverride) {
+    const overrideKeys = sortStrings(
+      Object.keys(params.payload.collectionsOverride)
+    ).join(",");
+    params.diag.push(
+      `[WorkerSyncDiag] collections overrideKeys=${overrideKeys || "(none)"}`
     );
   }
   return collections;
@@ -1786,6 +2108,7 @@ async function reloadCollectionsAfterPush(params: {
   diag: string[];
   perfDebugEnabled: boolean;
   perfMinDurationMs: number;
+  requiredCollectionNames: ReadonlySet<string>;
 }): Promise<void> {
   if (params.payload.changes.length === 0) {
     if (params.diagnosticsEnabled) {
@@ -1796,14 +2119,15 @@ async function reloadCollectionsAfterPush(params: {
     return;
   }
 
-  params.ctx.collections = await loadCollectionsForSync(
-    params.tx,
-    params.authUserId,
-    params.payload,
-    params.perfDebugEnabled,
-    params.perfMinDurationMs,
-    params.diagnosticsEnabled ? params.diag : undefined
-  );
+  params.ctx.collections = await loadCollectionsForSync({
+    tx: params.tx,
+    authUserId: params.authUserId,
+    payload: params.payload,
+    requiredCollectionNames: params.requiredCollectionNames,
+    perfDebugEnabled: params.perfDebugEnabled,
+    perfMinDurationMs: params.perfMinDurationMs,
+    diag: params.diagnosticsEnabled ? params.diag : undefined,
+  });
 }
 
 async function processPullForSync(
@@ -1833,7 +2157,6 @@ async function processPullForSync(
   const page = await processInitialSyncPaged(
     tx,
     ctx,
-    payload.pullCursor,
     payload.syncStartedAt,
     payload.pageSize,
     payload.initialPageCount
@@ -1857,6 +2180,8 @@ async function runSyncTransaction(params: {
   payload: SyncRequest;
   userId: string;
   now: string;
+  cursorSecret?: string;
+  initialCursor?: DecodedInitialSyncCursor;
   diagnosticsEnabled: boolean;
   perfDebugEnabled: boolean;
   perfMinDurationMs: number;
@@ -1865,15 +2190,18 @@ async function runSyncTransaction(params: {
 }): Promise<SyncTransactionResult> {
   const txStartedAt = Date.now();
   const authUserId = params.userId;
-  const collections = await loadCollectionsForSync(
-    params.tx,
-    authUserId,
-    params.payload,
-    params.perfDebugEnabled,
-    params.perfMinDurationMs,
-    params.diagnosticsEnabled ? params.diag : undefined
-  );
   const pullTables = buildPullTables(params.payload.pullTables);
+  const requiredCollectionNames = getRequiredCollectionNames(pullTables);
+  const collections = await loadCollectionsForSync({
+    tx: params.tx,
+    authUserId,
+    payload: params.payload,
+    requiredCollectionNames,
+    carriedCollections: params.initialCursor?.collections,
+    perfDebugEnabled: params.perfDebugEnabled,
+    perfMinDurationMs: params.perfMinDurationMs,
+    diag: params.diagnosticsEnabled ? params.diag : undefined,
+  });
   logPullTableMode(pullTables);
 
   const ctx: SyncContext = {
@@ -1886,6 +2214,8 @@ async function runSyncTransaction(params: {
     diagnosticsEnabled: params.diagnosticsEnabled,
     perfDebugEnabled: params.perfDebugEnabled,
     perfMinDurationMs: params.perfMinDurationMs,
+    cursorSecret: params.cursorSecret,
+    initialCursor: params.initialCursor,
   };
 
   const pushStartedAt = Date.now();
@@ -1908,6 +2238,7 @@ async function runSyncTransaction(params: {
     diag: params.diag,
     perfDebugEnabled: params.perfDebugEnabled,
     perfMinDurationMs: params.perfMinDurationMs,
+    requiredCollectionNames,
   });
 
   const result = await processPullForSync(
@@ -1947,46 +2278,59 @@ async function runSyncTransaction(params: {
   return result;
 }
 
-async function handleSync(
-  db: ReturnType<typeof drizzle>,
-  payload: SyncRequest,
-  userId: string,
-  diagnosticsEnabled: boolean,
-  perfDebugEnabled: boolean,
-  perfMinDurationMs: number,
-  initialDiagnostics: string[] = []
-): Promise<SyncResponse> {
+async function handleSync(params: {
+  db: ReturnType<typeof drizzle>;
+  payload: SyncRequest;
+  userId: string;
+  cursorSecret?: string;
+  diagnosticsEnabled: boolean;
+  perfDebugEnabled: boolean;
+  perfMinDurationMs: number;
+  initialDiagnostics?: string[];
+}): Promise<SyncResponse> {
   const now = new Date().toISOString();
-  const diag: string[] = [...initialDiagnostics];
+  const diag: string[] = [...(params.initialDiagnostics ?? [])];
   let responseChanges: SyncChange[] = [];
   let nextCursor: string | undefined;
   let syncStartedAt: string | undefined;
-  const syncType = payload.lastSyncAt ? "INCREMENTAL" : "INITIAL";
+  const syncType = params.payload.lastSyncAt ? "INCREMENTAL" : "INITIAL";
   const syncStartedAtMs = Date.now();
+  const initialCursor =
+    !params.payload.lastSyncAt && params.payload.pullCursor
+      ? await decodeCursor(
+          params.payload.pullCursor,
+          params.userId,
+          params.cursorSecret
+        )
+      : undefined;
 
   perfLog(
-    perfDebugEnabled,
-    `sync.start type=${syncType} changesIn=${payload.changes.length} lastSyncAt=${payload.lastSyncAt ?? "null"} pageSize=${payload.pageSize ?? "null"} initialPageCount=${payload.initialPageCount ?? "null"} hasCursor=${payload.pullCursor ? "yes" : "no"}`
+    params.perfDebugEnabled,
+    `sync.start type=${syncType} changesIn=${params.payload.changes.length} lastSyncAt=${params.payload.lastSyncAt ?? "null"} pageSize=${params.payload.pageSize ?? "null"} initialPageCount=${params.payload.initialPageCount ?? "null"} hasCursor=${params.payload.pullCursor ? "yes" : "no"}`
   );
 
-  if (diagnosticsEnabled) {
-    addStartDiagnostics(diag, payload, syncType);
+  if (params.diagnosticsEnabled) {
+    addStartDiagnostics(diag, params.payload, syncType, initialCursor);
   }
 
-  debug.log(`[SYNC] === Starting ${syncType} sync for user ${userId} ===`);
   debug.log(
-    `[SYNC] Request: lastSyncAt=${payload.lastSyncAt ?? "null"}, changes=${payload.changes.length}`
+    `[SYNC] === Starting ${syncType} sync for user ${params.userId} ===`
+  );
+  debug.log(
+    `[SYNC] Request: lastSyncAt=${params.payload.lastSyncAt ?? "null"}, changes=${params.payload.changes.length}`
   );
 
-  await db.transaction(async (tx) => {
+  await params.db.transaction(async (tx) => {
     const result = await runSyncTransaction({
       tx,
-      payload,
-      userId,
+      payload: params.payload,
+      userId: params.userId,
       now,
-      diagnosticsEnabled,
-      perfDebugEnabled,
-      perfMinDurationMs,
+      cursorSecret: params.cursorSecret,
+      initialCursor,
+      diagnosticsEnabled: params.diagnosticsEnabled,
+      perfDebugEnabled: params.perfDebugEnabled,
+      perfMinDurationMs: params.perfMinDurationMs,
       syncType,
       diag,
     });
@@ -2000,12 +2344,12 @@ async function handleSync(
   );
 
   perfLogDuration(
-    perfDebugEnabled,
-    perfMinDurationMs,
+    params.perfDebugEnabled,
+    params.perfMinDurationMs,
     Date.now() - syncStartedAtMs,
     `sync.complete type=${syncType} changesOut=${responseChanges.length} total`
   );
-  if (diagnosticsEnabled) {
+  if (params.diagnosticsEnabled) {
     diag.push(`[WorkerSyncDiag] sync totalMs=${Date.now() - syncStartedAtMs}`);
   }
 
@@ -2014,7 +2358,7 @@ async function handleSync(
     syncedAt: now,
     nextCursor,
     syncStartedAt,
-    debug: diagnosticsEnabled ? diag : undefined,
+    debug: params.diagnosticsEnabled ? diag : undefined,
   };
 }
 
@@ -2077,6 +2421,10 @@ function isSyncDiagnosticsEnabled(
     env.SYNC_DIAGNOSTICS === "true" &&
     (!env.SYNC_DIAGNOSTICS_USER_ID || env.SYNC_DIAGNOSTICS_USER_ID === userId)
   );
+}
+
+function getCursorSecret(env: Env): string | undefined {
+  return env.OOSYNC_CURSOR_SECRET || env.SUPABASE_JWT_SECRET;
 }
 
 async function authorizeSyncRequest(
@@ -2168,15 +2516,16 @@ async function runSyncWithDb(params: {
   let dbCloseDurationMs: number | undefined;
   let response: SyncResponse;
   try {
-    response = await handleSync(
+    response = await handleSync({
       db,
       payload,
       userId,
+      cursorSecret: getCursorSecret(env),
       diagnosticsEnabled,
       perfDebugEnabled,
       perfMinDurationMs,
-      requestDiagnostics
-    );
+      initialDiagnostics: requestDiagnostics,
+    });
   } finally {
     const closeStartedAt = Date.now();
     await close();

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -362,6 +362,11 @@ interface InitialSyncPageState {
   offset: number;
 }
 
+interface InitialSyncPageBudget {
+  pageSize: number;
+  pageCount: number;
+}
+
 function encodeCursor(cursor: InitialSyncCursorV1): string {
   return btoa(JSON.stringify(cursor));
 }
@@ -411,6 +416,49 @@ function encodeNextInitialSyncCursor(
     offset: state.offset,
     syncStartedAt,
   });
+}
+
+function normalizePositiveIntegerHint(
+  value: number | undefined,
+  defaultValue: number,
+  maxValue: number
+): number {
+  const requested =
+    typeof value === "number" && Number.isFinite(value)
+      ? Math.max(1, Math.floor(value))
+      : defaultValue;
+  return Math.min(requested, maxValue);
+}
+
+function getInitialSyncPageBudget(
+  pageSizeHint: number | undefined,
+  pageCountHint: number | undefined
+): InitialSyncPageBudget {
+  return {
+    pageSize: normalizePositiveIntegerHint(pageSizeHint, 500, 500),
+    pageCount: normalizePositiveIntegerHint(pageCountHint, 1, 32),
+  };
+}
+
+function getInitialSyncStartState(params: {
+  cursorRaw?: string;
+  syncStartedAtHint?: string;
+  now: string;
+}): InitialSyncPageState & { syncStartedAt: string } {
+  if (!params.cursorRaw) {
+    return {
+      tableIndex: 0,
+      offset: 0,
+      syncStartedAt: params.syncStartedAtHint ?? params.now,
+    };
+  }
+
+  const cursor = decodeCursor(params.cursorRaw);
+  return {
+    tableIndex: cursor.tableIndex,
+    offset: cursor.offset,
+    syncStartedAt: cursor.syncStartedAt,
+  };
 }
 
 type DrizzleColumn = AnyPgColumn;
@@ -1136,38 +1184,22 @@ async function processInitialSyncPaged(
   changes: SyncChange[];
   nextCursor?: string;
   syncStartedAt: string;
+  diagnostics: string[];
 }> {
-  const MAX_PAGE_SIZE = 500;
-  const DEFAULT_PAGE_SIZE = 500;
-  const MAX_PAGE_COUNT = 32;
-  const DEFAULT_PAGE_COUNT = 1;
-  const requested =
-    typeof pageSizeHint === "number" && Number.isFinite(pageSizeHint)
-      ? Math.max(1, Math.floor(pageSizeHint))
-      : DEFAULT_PAGE_SIZE;
-  const pageSize = Math.min(requested, MAX_PAGE_SIZE);
-  const requestedPageCount =
-    typeof pageCountHint === "number" && Number.isFinite(pageCountHint)
-      ? Math.max(1, Math.floor(pageCountHint))
-      : DEFAULT_PAGE_COUNT;
-  const pageCount = Math.min(requestedPageCount, MAX_PAGE_COUNT);
-
-  let tableIndex = 0;
-  let offset = 0;
-  let syncStartedAt = syncStartedAtHint;
+  const { pageSize, pageCount } = getInitialSyncPageBudget(
+    pageSizeHint,
+    pageCountHint
+  );
+  const startState = getInitialSyncStartState({
+    cursorRaw,
+    syncStartedAtHint,
+    now: ctx.now,
+  });
+  let { tableIndex, offset } = startState;
+  const { syncStartedAt } = startState;
   const allChanges: SyncChange[] = [];
+  const diagnostics: string[] = [];
   let pagesCollected = 0;
-
-  if (cursorRaw) {
-    const cursor = decodeCursor(cursorRaw);
-    tableIndex = cursor.tableIndex;
-    offset = cursor.offset;
-    syncStartedAt = cursor.syncStartedAt;
-  }
-
-  if (!syncStartedAt) {
-    syncStartedAt = ctx.now;
-  }
 
   // Advance until we fill the requested page budget or finish all tables.
   while (tableIndex < SYNCABLE_TABLES.length && pagesCollected < pageCount) {
@@ -1186,12 +1218,18 @@ async function processInitialSyncPaged(
       offset,
       pageSize
     );
+    const pageDurationMs = Date.now() - pageStartedAt;
     perfLogDuration(
       ctx.perfDebugEnabled,
       ctx.perfMinDurationMs,
-      Date.now() - pageStartedAt,
+      pageDurationMs,
       `initial.page table=${tableName} offset=${offset} limit=${pageSize} rows=${changes.length}`
     );
+    if (ctx.diagnosticsEnabled) {
+      diagnostics.push(
+        `[WorkerSyncDiag] initialPage table=${tableName} offset=${offset} limit=${pageSize} rows=${changes.length} durationMs=${pageDurationMs}`
+      );
+    }
 
     if (changes.length === 0) {
       // Either table is empty / skipped OR we've paged past the end.
@@ -1222,6 +1260,7 @@ async function processInitialSyncPaged(
       { tableIndex, offset },
       syncStartedAt
     ),
+    diagnostics,
   };
 }
 
@@ -1398,6 +1437,7 @@ interface SyncTransactionResult {
   responseChanges: SyncChange[];
   nextCursor?: string;
   syncStartedAt?: string;
+  diagnostics?: string[];
 }
 
 function getCursorSummary(payload: SyncRequest): string {
@@ -1554,6 +1594,7 @@ async function processPullForSync(
     responseChanges: page.changes,
     nextCursor: page.nextCursor,
     syncStartedAt: page.syncStartedAt,
+    diagnostics: page.diagnostics,
   };
 }
 
@@ -1620,6 +1661,9 @@ async function runSyncTransaction(params: {
   );
 
   if (params.diagnosticsEnabled) {
+    if (result.diagnostics) {
+      params.diag.push(...result.diagnostics);
+    }
     addResponseDiagnostics(
       params.diag,
       result.responseChanges,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -48,10 +48,7 @@ function notInitialized(name: string): never {
 
 let schemaTables: SchemaTables | null = null;
 let SYNCABLE_TABLES: readonly string[] = [];
-let TABLE_REGISTRY: Record<
-  string,
-  { relationKind?: "table" | "view" | "materialized_view" | string }
-> = {};
+let TABLE_REGISTRY: Record<string, { relationKind?: string }> = {};
 
 let getPrimaryKey: (tableName: string) => string | string[] = () =>
   notInitialized("getPrimaryKey");
@@ -1948,6 +1945,221 @@ function errorResponse(
   return jsonResponse({ error: message }, corsHeaders, status);
 }
 
+interface SyncPostRequestParams {
+  request: Request;
+  env: Env;
+  corsHeaders: Record<string, string>;
+  perfDebugEnabled: boolean;
+  perfMinDurationMs: number;
+  requestStartedAt: number;
+}
+
+function isSyncDiagnosticsEnabled(
+  env: Env,
+  userId: string,
+  payload: SyncRequest
+): boolean {
+  return (
+    payload.diagnostics === true &&
+    env.SYNC_DIAGNOSTICS === "true" &&
+    (!env.SYNC_DIAGNOSTICS_USER_ID || env.SYNC_DIAGNOSTICS_USER_ID === userId)
+  );
+}
+
+async function authorizeSyncRequest(
+  request: Request,
+  env: Env,
+  perfDebugEnabled: boolean,
+  perfMinDurationMs: number
+): Promise<{ userId: string | null; authDurationMs: number }> {
+  const authStartedAt = Date.now();
+  const userId = await verifyJwt(
+    request,
+    env.SUPABASE_JWT_SECRET,
+    env.SUPABASE_URL
+  );
+  const authDurationMs = Date.now() - authStartedAt;
+  perfLogDuration(
+    perfDebugEnabled,
+    perfMinDurationMs,
+    authDurationMs,
+    `http.sync.auth authorized=${userId ? "yes" : "no"}`
+  );
+  return { userId, authDurationMs };
+}
+
+async function parseSyncPayload(
+  request: Request,
+  perfDebugEnabled: boolean,
+  perfMinDurationMs: number
+): Promise<{ payload: SyncRequest; payloadParseDurationMs: number }> {
+  const payloadStartedAt = Date.now();
+  const payload: SyncRequest = await request.json();
+  const payloadParseDurationMs = Date.now() - payloadStartedAt;
+  perfLogDuration(
+    perfDebugEnabled,
+    perfMinDurationMs,
+    payloadParseDurationMs,
+    `http.sync.payload.parse changesIn=${payload.changes.length}`
+  );
+  return { payload, payloadParseDurationMs };
+}
+
+function appendHttpDiagnostics(
+  response: SyncResponse,
+  dbCloseDurationMs: number | undefined,
+  handleSyncStartedAt: number,
+  requestStartedAt: number
+): void {
+  response.debug ??= [];
+  response.debug.push(
+    `[WorkerSyncDiag] http dbCloseMs=${dbCloseDurationMs ?? "unknown"}`,
+    `[WorkerSyncDiag] http handleMs=${Date.now() - handleSyncStartedAt} requestTotalMs=${Date.now() - requestStartedAt} responseBytesApprox=${estimateJsonBytes(response)}`
+  );
+}
+
+async function runSyncWithDb(params: {
+  env: Env;
+  payload: SyncRequest;
+  userId: string;
+  diagnosticsEnabled: boolean;
+  perfDebugEnabled: boolean;
+  perfMinDurationMs: number;
+  requestDiagnostics: string[];
+}): Promise<{ response: SyncResponse; dbCloseDurationMs: number | undefined }> {
+  const {
+    env,
+    payload,
+    userId,
+    diagnosticsEnabled,
+    perfDebugEnabled,
+    perfMinDurationMs,
+    requestDiagnostics,
+  } = params;
+  debug.log(`[HTTP] Sync request parsed, calling handleSync`);
+  const createDbStartedAt = Date.now();
+  const { db, close } = createDb(env);
+  const dbCreateDurationMs = Date.now() - createDbStartedAt;
+  if (diagnosticsEnabled) {
+    requestDiagnostics.push(
+      `[WorkerSyncDiag] http dbCreateMs=${dbCreateDurationMs}`
+    );
+  }
+  perfLogDuration(
+    perfDebugEnabled,
+    perfMinDurationMs,
+    dbCreateDurationMs,
+    "http.sync.db.create"
+  );
+
+  let dbCloseDurationMs: number | undefined;
+  let response: SyncResponse;
+  try {
+    response = await handleSync(
+      db,
+      payload,
+      userId,
+      diagnosticsEnabled,
+      perfDebugEnabled,
+      perfMinDurationMs,
+      requestDiagnostics
+    );
+  } finally {
+    const closeStartedAt = Date.now();
+    await close();
+    dbCloseDurationMs = Date.now() - closeStartedAt;
+    perfLogDuration(
+      perfDebugEnabled,
+      perfMinDurationMs,
+      dbCloseDurationMs,
+      "http.sync.db.close"
+    );
+  }
+  return { response, dbCloseDurationMs };
+}
+
+async function handleSyncPostRequest(
+  params: SyncPostRequestParams
+): Promise<Response> {
+  const {
+    request,
+    env,
+    corsHeaders,
+    perfDebugEnabled,
+    perfMinDurationMs,
+    requestStartedAt,
+  } = params;
+  debug.log(`[HTTP] POST /api/sync received`);
+  perfLog(perfDebugEnabled, "http.sync.request.received");
+
+  const { userId, authDurationMs } = await authorizeSyncRequest(
+    request,
+    env,
+    perfDebugEnabled,
+    perfMinDurationMs
+  );
+  if (!userId) {
+    debug.log(`[HTTP] Unauthorized - JWT verification failed`);
+    return errorResponse("Unauthorized", corsHeaders, 401);
+  }
+
+  const { payload, payloadParseDurationMs } = await parseSyncPayload(
+    request,
+    perfDebugEnabled,
+    perfMinDurationMs
+  );
+  const diagnosticsEnabled = isSyncDiagnosticsEnabled(env, userId, payload);
+  const requestDiagnostics = diagnosticsEnabled
+    ? [
+        `[WorkerSyncDiag] http authMs=${authDurationMs} payloadParseMs=${payloadParseDurationMs}`,
+      ]
+    : [];
+
+  try {
+    const handleSyncStartedAt = Date.now();
+    const { response, dbCloseDurationMs } = await runSyncWithDb({
+      env,
+      payload,
+      userId,
+      diagnosticsEnabled,
+      perfDebugEnabled,
+      perfMinDurationMs,
+      requestDiagnostics,
+    });
+    if (diagnosticsEnabled) {
+      appendHttpDiagnostics(
+        response,
+        dbCloseDurationMs,
+        handleSyncStartedAt,
+        requestStartedAt
+      );
+    }
+    perfLogDuration(
+      perfDebugEnabled,
+      perfMinDurationMs,
+      Date.now() - handleSyncStartedAt,
+      "http.sync.handle"
+    );
+    perfLogDuration(
+      perfDebugEnabled,
+      perfMinDurationMs,
+      Date.now() - requestStartedAt,
+      "http.sync.request.total"
+    );
+    debug.log(`[HTTP] Sync completed successfully`);
+    return jsonResponse(response, corsHeaders);
+  } catch (error) {
+    perfLogDuration(
+      perfDebugEnabled,
+      perfMinDurationMs,
+      Date.now() - requestStartedAt,
+      "http.sync.request.failed"
+    );
+    console.error("[HTTP] Sync error:", error);
+    return errorResponse(formatDbError(error), corsHeaders);
+  }
+}
+
 async function fetch(request: Request, env: Env): Promise<Response> {
   // Initialize debug logging based on environment variable
   setDebugEnabled(env);
@@ -1978,125 +2190,14 @@ async function fetch(request: Request, env: Env): Promise<Response> {
 
     // Sync endpoint
     if (request.method === "POST" && url.pathname === "/api/sync") {
-      debug.log(`[HTTP] POST /api/sync received`);
-      perfLog(perfDebugEnabled, "http.sync.request.received");
-
-      // Authenticate
-      const authStartedAt = Date.now();
-      const userId = await verifyJwt(
+      return await handleSyncPostRequest({
         request,
-        env.SUPABASE_JWT_SECRET,
-        env.SUPABASE_URL
-      );
-      const authDurationMs = Date.now() - authStartedAt;
-      perfLogDuration(
+        env,
+        corsHeaders,
         perfDebugEnabled,
         perfMinDurationMs,
-        authDurationMs,
-        `http.sync.auth authorized=${userId ? "yes" : "no"}`
-      );
-      if (!userId) {
-        debug.log(`[HTTP] Unauthorized - JWT verification failed`);
-        return errorResponse("Unauthorized", corsHeaders, 401);
-      }
-
-      const payloadStartedAt = Date.now();
-      const payload: SyncRequest = await request.json();
-      const payloadParseDurationMs = Date.now() - payloadStartedAt;
-      const diagnosticsAllowed =
-        env.SYNC_DIAGNOSTICS === "true" &&
-        (!env.SYNC_DIAGNOSTICS_USER_ID ||
-          env.SYNC_DIAGNOSTICS_USER_ID === userId);
-      const diagnosticsEnabled =
-        diagnosticsAllowed && payload.diagnostics === true;
-      const requestDiagnostics = diagnosticsEnabled
-        ? [
-            `[WorkerSyncDiag] http authMs=${authDurationMs} payloadParseMs=${payloadParseDurationMs}`,
-          ]
-        : [];
-      perfLogDuration(
-        perfDebugEnabled,
-        perfMinDurationMs,
-        payloadParseDurationMs,
-        `http.sync.payload.parse changesIn=${payload.changes.length}`
-      );
-
-      // Connect to database
-      try {
-        debug.log(`[HTTP] Sync request parsed, calling handleSync`);
-        const createDbStartedAt = Date.now();
-        const { db, close } = createDb(env);
-        const dbCreateDurationMs = Date.now() - createDbStartedAt;
-        if (diagnosticsEnabled) {
-          requestDiagnostics.push(
-            `[WorkerSyncDiag] http dbCreateMs=${dbCreateDurationMs}`
-          );
-        }
-        perfLogDuration(
-          perfDebugEnabled,
-          perfMinDurationMs,
-          dbCreateDurationMs,
-          "http.sync.db.create"
-        );
-
-        const handleSyncStartedAt = Date.now();
-        let dbCloseDurationMs: number | undefined;
-        const response = await (async () => {
-          try {
-            return await handleSync(
-              db,
-              payload,
-              userId,
-              diagnosticsEnabled,
-              perfDebugEnabled,
-              perfMinDurationMs,
-              requestDiagnostics
-            );
-          } finally {
-            const closeStartedAt = Date.now();
-            await close();
-            dbCloseDurationMs = Date.now() - closeStartedAt;
-            perfLogDuration(
-              perfDebugEnabled,
-              perfMinDurationMs,
-              dbCloseDurationMs,
-              "http.sync.db.close"
-            );
-          }
-        })();
-        if (diagnosticsEnabled) {
-          response.debug ??= [];
-          response.debug.push(
-            `[WorkerSyncDiag] http dbCloseMs=${dbCloseDurationMs ?? "unknown"}`
-          );
-          response.debug.push(
-            `[WorkerSyncDiag] http handleMs=${Date.now() - handleSyncStartedAt} requestTotalMs=${Date.now() - requestStartedAt} responseBytesApprox=${estimateJsonBytes(response)}`
-          );
-        }
-        perfLogDuration(
-          perfDebugEnabled,
-          perfMinDurationMs,
-          Date.now() - handleSyncStartedAt,
-          "http.sync.handle"
-        );
-        perfLogDuration(
-          perfDebugEnabled,
-          perfMinDurationMs,
-          Date.now() - requestStartedAt,
-          "http.sync.request.total"
-        );
-        debug.log(`[HTTP] Sync completed successfully`);
-        return jsonResponse(response, corsHeaders);
-      } catch (error) {
-        perfLogDuration(
-          perfDebugEnabled,
-          perfMinDurationMs,
-          Date.now() - requestStartedAt,
-          "http.sync.request.failed"
-        );
-        console.error("[HTTP] Sync error:", error);
-        return errorResponse(formatDbError(error), corsHeaders);
-      }
+        requestStartedAt,
+      });
     }
 
     return new Response("Not Found", { status: 404, headers: corsHeaders });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1667,6 +1667,35 @@ async function loadCollectionsForSync(
   return collections;
 }
 
+async function reloadCollectionsAfterPush(params: {
+  ctx: SyncContext;
+  tx: Transaction;
+  authUserId: string;
+  payload: SyncRequest;
+  diagnosticsEnabled: boolean;
+  diag: string[];
+  perfDebugEnabled: boolean;
+  perfMinDurationMs: number;
+}): Promise<void> {
+  if (params.payload.changes.length === 0) {
+    if (params.diagnosticsEnabled) {
+      params.diag.push(
+        "[WorkerSyncDiag] collections reuseAfterPush=yes reason=no-changes"
+      );
+    }
+    return;
+  }
+
+  params.ctx.collections = await loadCollectionsForSync(
+    params.tx,
+    params.authUserId,
+    params.payload,
+    params.perfDebugEnabled,
+    params.perfMinDurationMs,
+    params.diagnosticsEnabled ? params.diag : undefined
+  );
+}
+
 async function processPullForSync(
   tx: Transaction,
   payload: SyncRequest,
@@ -1760,14 +1789,16 @@ async function runSyncTransaction(params: {
 
   // Reload collections after push so the pull phase sees any collection/ownership
   // changes written during the push (e.g. newly created rows in collection-backed tables).
-  ctx.collections = await loadCollectionsForSync(
-    params.tx,
+  await reloadCollectionsAfterPush({
+    ctx,
+    tx: params.tx,
     authUserId,
-    params.payload,
-    params.perfDebugEnabled,
-    params.perfMinDurationMs,
-    params.diagnosticsEnabled ? params.diag : undefined
-  );
+    payload: params.payload,
+    diagnosticsEnabled: params.diagnosticsEnabled,
+    diag: params.diag,
+    perfDebugEnabled: params.perfDebugEnabled,
+    perfMinDurationMs: params.perfMinDurationMs,
+  });
 
   const result = await processPullForSync(
     params.tx,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -357,6 +357,11 @@ interface InitialSyncCursorV1 {
   syncStartedAt: string;
 }
 
+interface InitialSyncPageState {
+  tableIndex: number;
+  offset: number;
+}
+
 function encodeCursor(cursor: InitialSyncCursorV1): string {
   return btoa(JSON.stringify(cursor));
 }
@@ -390,6 +395,22 @@ function decodeCursor(raw: string): InitialSyncCursorV1 {
   }
 
   return { v: 1, tableIndex, offset, syncStartedAt };
+}
+
+function encodeNextInitialSyncCursor(
+  state: InitialSyncPageState,
+  syncStartedAt: string
+): string | undefined {
+  if (state.tableIndex >= SYNCABLE_TABLES.length) {
+    return undefined;
+  }
+
+  return encodeCursor({
+    v: 1,
+    tableIndex: state.tableIndex,
+    offset: state.offset,
+    syncStartedAt,
+  });
 }
 
 type DrizzleColumn = AnyPgColumn;
@@ -1109,7 +1130,8 @@ async function processInitialSyncPaged(
   ctx: SyncContext,
   cursorRaw: string | undefined,
   syncStartedAtHint: string | undefined,
-  pageSizeHint: number | undefined
+  pageSizeHint: number | undefined,
+  pageCountHint: number | undefined
 ): Promise<{
   changes: SyncChange[];
   nextCursor?: string;
@@ -1117,15 +1139,24 @@ async function processInitialSyncPaged(
 }> {
   const MAX_PAGE_SIZE = 500;
   const DEFAULT_PAGE_SIZE = 500;
+  const MAX_PAGE_COUNT = 32;
+  const DEFAULT_PAGE_COUNT = 1;
   const requested =
     typeof pageSizeHint === "number" && Number.isFinite(pageSizeHint)
       ? Math.max(1, Math.floor(pageSizeHint))
       : DEFAULT_PAGE_SIZE;
   const pageSize = Math.min(requested, MAX_PAGE_SIZE);
+  const requestedPageCount =
+    typeof pageCountHint === "number" && Number.isFinite(pageCountHint)
+      ? Math.max(1, Math.floor(pageCountHint))
+      : DEFAULT_PAGE_COUNT;
+  const pageCount = Math.min(requestedPageCount, MAX_PAGE_COUNT);
 
   let tableIndex = 0;
   let offset = 0;
   let syncStartedAt = syncStartedAtHint;
+  const allChanges: SyncChange[] = [];
+  let pagesCollected = 0;
 
   if (cursorRaw) {
     const cursor = decodeCursor(cursorRaw);
@@ -1138,8 +1169,8 @@ async function processInitialSyncPaged(
     syncStartedAt = ctx.now;
   }
 
-  // Advance until we find a table with rows to return, or we finish.
-  while (tableIndex < SYNCABLE_TABLES.length) {
+  // Advance until we fill the requested page budget or finish all tables.
+  while (tableIndex < SYNCABLE_TABLES.length && pagesCollected < pageCount) {
     const tableName = SYNCABLE_TABLES[tableIndex];
     if (ctx.pullTables && !ctx.pullTables.has(tableName)) {
       tableIndex += 1;
@@ -1172,37 +1203,26 @@ async function processInitialSyncPaged(
 
     const nextOffset = offset + changes.length;
     const isLastPageForTable = changes.length < pageSize;
+    allChanges.push(...changes);
+    pagesCollected += 1;
 
     if (isLastPageForTable) {
-      const nextTableIndex = tableIndex + 1;
-      if (nextTableIndex >= SYNCABLE_TABLES.length) {
-        return { changes, syncStartedAt };
-      }
-      return {
-        changes,
-        syncStartedAt,
-        nextCursor: encodeCursor({
-          v: 1,
-          tableIndex: nextTableIndex,
-          offset: 0,
-          syncStartedAt,
-        }),
-      };
+      tableIndex += 1;
+      offset = 0;
+      continue;
     }
 
-    return {
-      changes,
-      syncStartedAt,
-      nextCursor: encodeCursor({
-        v: 1,
-        tableIndex,
-        offset: nextOffset,
-        syncStartedAt,
-      }),
-    };
+    offset = nextOffset;
   }
 
-  return { changes: [], syncStartedAt };
+  return {
+    changes: allChanges,
+    syncStartedAt,
+    nextCursor: encodeNextInitialSyncCursor(
+      { tableIndex, offset },
+      syncStartedAt
+    ),
+  };
 }
 
 // ============================================================================
@@ -1399,7 +1419,7 @@ function addStartDiagnostics(
   syncType: SyncType
 ): void {
   diag.push(
-    `[WorkerSyncDiag] type=${syncType} changesIn=${payload.changes.length} lastSyncAt=${payload.lastSyncAt ?? "null"} pageSize=${payload.pageSize ?? "null"} ${getCursorSummary(payload)}`
+    `[WorkerSyncDiag] type=${syncType} changesIn=${payload.changes.length} lastSyncAt=${payload.lastSyncAt ?? "null"} pageSize=${payload.pageSize ?? "null"} initialPageCount=${payload.initialPageCount ?? "null"} ${getCursorSummary(payload)}`
   );
 }
 
@@ -1521,13 +1541,14 @@ async function processPullForSync(
     ctx,
     payload.pullCursor,
     payload.syncStartedAt,
-    payload.pageSize
+    payload.pageSize,
+    payload.initialPageCount
   );
   perfLogDuration(
     perfDebugEnabled,
     perfMinDurationMs,
     Date.now() - pullStartedAt,
-    `sync.pull.initial pageChanges=${page.changes.length} nextCursor=${page.nextCursor ? "yes" : "no"}`
+    `sync.pull.initial pageChanges=${page.changes.length} pageCount=${payload.initialPageCount ?? "default"} nextCursor=${page.nextCursor ? "yes" : "no"}`
   );
   return {
     responseChanges: page.changes,
@@ -1637,7 +1658,7 @@ async function handleSync(
 
   perfLog(
     perfDebugEnabled,
-    `sync.start type=${syncType} changesIn=${payload.changes.length} lastSyncAt=${payload.lastSyncAt ?? "null"} pageSize=${payload.pageSize ?? "null"} hasCursor=${payload.pullCursor ? "yes" : "no"}`
+    `sync.start type=${syncType} changesIn=${payload.changes.length} lastSyncAt=${payload.lastSyncAt ?? "null"} pageSize=${payload.pageSize ?? "null"} initialPageCount=${payload.initialPageCount ?? "null"} hasCursor=${payload.pullCursor ? "yes" : "no"}`
   );
 
   if (diagnosticsEnabled) {
@@ -1709,8 +1730,8 @@ function getCorsHeaders(request: Request): Record<string, string> {
 
 function jsonResponse(
   data: unknown,
-  status = 200,
-  corsHeaders: Record<string, string>
+  corsHeaders: Record<string, string>,
+  status = 200
 ): Response {
   return new Response(JSON.stringify(data), {
     status,
@@ -1720,10 +1741,10 @@ function jsonResponse(
 
 function errorResponse(
   message: string,
-  status = 500,
-  corsHeaders: Record<string, string>
+  corsHeaders: Record<string, string>,
+  status = 500
 ): Response {
-  return jsonResponse({ error: message }, status, corsHeaders);
+  return jsonResponse({ error: message }, corsHeaders, status);
 }
 
 async function fetch(request: Request, env: Env): Promise<Response> {
@@ -1774,7 +1795,7 @@ async function fetch(request: Request, env: Env): Promise<Response> {
       );
       if (!userId) {
         debug.log(`[HTTP] Unauthorized - JWT verification failed`);
-        return errorResponse("Unauthorized", 401, corsHeaders);
+        return errorResponse("Unauthorized", corsHeaders, 401);
       }
 
       const diagnosticsEnabled =
@@ -1838,7 +1859,7 @@ async function fetch(request: Request, env: Env): Promise<Response> {
           "http.sync.request.total"
         );
         debug.log(`[HTTP] Sync completed successfully`);
-        return jsonResponse(response, 200, corsHeaders);
+        return jsonResponse(response, corsHeaders);
       } catch (error) {
         perfLogDuration(
           perfDebugEnabled,
@@ -1847,13 +1868,13 @@ async function fetch(request: Request, env: Env): Promise<Response> {
           "http.sync.request.failed"
         );
         console.error("[HTTP] Sync error:", error);
-        return errorResponse(formatDbError(error), 500, corsHeaders);
+        return errorResponse(formatDbError(error), corsHeaders);
       }
     }
 
     return new Response("Not Found", { status: 404, headers: corsHeaders });
   } catch (error) {
     console.error("[HTTP] Unhandled error:", error);
-    return errorResponse("Internal Server Error", 500, corsHeaders);
+    return errorResponse("Internal Server Error", corsHeaders);
   }
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -961,7 +961,8 @@ async function fetchViaRPC(
     const orderBy = (options.orderByColumns ?? [])
       .map((column) => `"${column.replaceAll('"', '""')}"`)
       .join(", ");
-    let queryString = `SELECT * FROM ${functionName}(${placeholders.join(", ")})${orderBy ? ` ORDER BY ${orderBy}` : ""}`;
+    const orderByClause = orderBy ? ` ORDER BY ${orderBy}` : "";
+    let queryString = `SELECT * FROM ${functionName}(${placeholders.join(", ")})${orderByClause}`;
     if (options.pageLimit !== undefined || options.pageOffset !== undefined) {
       paramValues.push(options.pageLimit ?? RPC_UNBOUNDED_PAGE_LIMIT);
       queryString += ` LIMIT $${paramValues.length}::INTEGER`;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -353,6 +353,7 @@ interface SyncContext {
 interface InitialPullPage {
   changes: SyncChange[];
   diagnostics: string[];
+  timing?: InitialPageTiming;
 }
 
 function getRelationKind(tableName: string): string {
@@ -371,7 +372,30 @@ function estimateJsonBytes(value: unknown): number {
   }
 }
 
-function createInitialPageDiagnostics(params: {
+interface InitialPageTiming {
+  tableName: string;
+  relationKind: string;
+  ruleKind: string;
+  offset: number;
+  limit: number;
+  rows: number;
+  queryDurationMs: number;
+  transformDurationMs: number;
+  totalDurationMs: number;
+  payloadBytes: number;
+}
+
+interface InitialTimingAggregate {
+  pages: number;
+  relations: Set<string>;
+  rows: number;
+  queryDurationMs: number;
+  transformDurationMs: number;
+  totalDurationMs: number;
+  payloadBytes: number;
+}
+
+function createInitialPageTiming(params: {
   tableName: string;
   ruleKind: string;
   offset: number;
@@ -381,21 +405,96 @@ function createInitialPageDiagnostics(params: {
   transformDurationMs: number;
   totalDurationMs: number;
   payloadBytes: number;
-}): string {
+}): InitialPageTiming {
+  return {
+    ...params,
+    relationKind: getRelationKind(params.tableName),
+  };
+}
+
+function createInitialPageDiagnostics(timing: InitialPageTiming): string {
   return [
     "[WorkerSyncDiag]",
     "initialPage",
-    `relation=${params.tableName}`,
-    `kind=${getRelationKind(params.tableName)}`,
-    `rule=${params.ruleKind}`,
-    `offset=${params.offset}`,
-    `limit=${params.limit}`,
-    `rows=${params.rows}`,
-    `queryMs=${params.queryDurationMs}`,
-    `transformMs=${params.transformDurationMs}`,
-    `payloadBytes=${params.payloadBytes}`,
-    `totalMs=${params.totalDurationMs}`,
+    `relation=${timing.tableName}`,
+    `kind=${timing.relationKind}`,
+    `rule=${timing.ruleKind}`,
+    `offset=${timing.offset}`,
+    `limit=${timing.limit}`,
+    `rows=${timing.rows}`,
+    `queryMs=${timing.queryDurationMs}`,
+    `transformMs=${timing.transformDurationMs}`,
+    `payloadBytes=${timing.payloadBytes}`,
+    `totalMs=${timing.totalDurationMs}`,
   ].join(" ");
+}
+
+function addInitialTimingAggregate(
+  aggregates: Map<string, InitialTimingAggregate>,
+  timing: InitialPageTiming
+): void {
+  const aggregate = aggregates.get(timing.relationKind) ?? {
+    pages: 0,
+    relations: new Set<string>(),
+    rows: 0,
+    queryDurationMs: 0,
+    transformDurationMs: 0,
+    totalDurationMs: 0,
+    payloadBytes: 0,
+  };
+  aggregate.pages += 1;
+  aggregate.relations.add(timing.tableName);
+  aggregate.rows += timing.rows;
+  aggregate.queryDurationMs += timing.queryDurationMs;
+  aggregate.transformDurationMs += timing.transformDurationMs;
+  aggregate.totalDurationMs += timing.totalDurationMs;
+  aggregate.payloadBytes += timing.payloadBytes;
+  aggregates.set(timing.relationKind, aggregate);
+}
+
+function createInitialKindDiagnostics(
+  aggregates: Map<string, InitialTimingAggregate>
+): string[] {
+  return [...aggregates.entries()]
+    .sort(([kindA], [kindB]) => kindA.localeCompare(kindB))
+    .map(([kind, aggregate]) =>
+      [
+        "[WorkerSyncDiag]",
+        "initialKind",
+        `kind=${kind}`,
+        `pages=${aggregate.pages}`,
+        `relations=${aggregate.relations.size}`,
+        `rows=${aggregate.rows}`,
+        `queryMs=${aggregate.queryDurationMs}`,
+        `transformMs=${aggregate.transformDurationMs}`,
+        `payloadBytes=${aggregate.payloadBytes}`,
+        `totalMs=${aggregate.totalDurationMs}`,
+      ].join(" ")
+    );
+}
+
+function createInitialRelationTopDiagnostics(
+  timings: InitialPageTiming[]
+): string | undefined {
+  const top = [...timings]
+    .sort((a, b) => b.totalDurationMs - a.totalDurationMs)
+    .slice(0, 8)
+    .map((timing) =>
+      [
+        timing.tableName,
+        `kind=${timing.relationKind}`,
+        `totalMs=${timing.totalDurationMs}`,
+        `queryMs=${timing.queryDurationMs}`,
+        `rows=${timing.rows}`,
+        `payloadBytes=${timing.payloadBytes}`,
+      ].join(":")
+    )
+    .join(",");
+
+  if (!top) {
+    return undefined;
+  }
+  return `[WorkerSyncDiag] initialRelationTop sort=totalMs relations=${top}`;
 }
 
 interface InitialSyncCursorV1 {
@@ -1181,21 +1280,21 @@ async function fetchTableForInitialSyncPage(
     }
     const transformDurationMs = Date.now() - transformStartedAt;
     const totalDurationMs = Date.now() - startedAt;
+    const timing = createInitialPageTiming({
+      tableName,
+      ruleKind: `rpc:${rule.functionName}`,
+      offset,
+      limit,
+      rows: changes.length,
+      queryDurationMs,
+      transformDurationMs,
+      totalDurationMs,
+      payloadBytes: estimatePayloadBytes(changes),
+    });
     return {
       changes,
-      diagnostics: [
-        createInitialPageDiagnostics({
-          tableName,
-          ruleKind: `rpc:${rule.functionName}`,
-          offset,
-          limit,
-          rows: changes.length,
-          queryDurationMs,
-          transformDurationMs,
-          totalDurationMs,
-          payloadBytes: estimatePayloadBytes(changes),
-        }),
-      ],
+      diagnostics: [createInitialPageDiagnostics(timing)],
+      timing,
     };
   }
 
@@ -1210,21 +1309,21 @@ async function fetchTableForInitialSyncPage(
     debug.log(
       `[PULL:INITIAL] Skipping ${tableName} (no matching rows for user)`
     );
+    const timing = createInitialPageTiming({
+      tableName,
+      ruleKind: "skipped:no-filter-match",
+      offset,
+      limit,
+      rows: 0,
+      queryDurationMs: 0,
+      transformDurationMs: 0,
+      totalDurationMs: Date.now() - startedAt,
+      payloadBytes: 0,
+    });
     return {
       changes: [],
-      diagnostics: [
-        createInitialPageDiagnostics({
-          tableName,
-          ruleKind: "skipped:no-filter-match",
-          offset,
-          limit,
-          rows: 0,
-          queryDurationMs: 0,
-          transformDurationMs: 0,
-          totalDurationMs: Date.now() - startedAt,
-          payloadBytes: 0,
-        }),
-      ],
+      diagnostics: [createInitialPageDiagnostics(timing)],
+      timing,
     };
   }
 
@@ -1259,21 +1358,21 @@ async function fetchTableForInitialSyncPage(
   }
   const transformDurationMs = Date.now() - transformStartedAt;
   const totalDurationMs = Date.now() - startedAt;
+  const timing = createInitialPageTiming({
+    tableName,
+    ruleKind: rule?.kind ?? "default",
+    offset,
+    limit,
+    rows: changes.length,
+    queryDurationMs,
+    transformDurationMs,
+    totalDurationMs,
+    payloadBytes: estimatePayloadBytes(changes),
+  });
   return {
     changes,
-    diagnostics: [
-      createInitialPageDiagnostics({
-        tableName,
-        ruleKind: rule?.kind ?? "default",
-        offset,
-        limit,
-        rows: changes.length,
-        queryDurationMs,
-        transformDurationMs,
-        totalDurationMs,
-        payloadBytes: estimatePayloadBytes(changes),
-      }),
-    ],
+    diagnostics: [createInitialPageDiagnostics(timing)],
+    timing,
   };
 }
 
@@ -1303,6 +1402,8 @@ async function processInitialSyncPaged(
   const { syncStartedAt } = startState;
   const allChanges: SyncChange[] = [];
   const diagnostics: string[] = [];
+  const timings: InitialPageTiming[] = [];
+  const timingAggregates = new Map<string, InitialTimingAggregate>();
   let pagesCollected = 0;
 
   // Advance until we fill the requested page budget or finish all tables.
@@ -1332,6 +1433,10 @@ async function processInitialSyncPaged(
     );
     if (ctx.diagnosticsEnabled) {
       diagnostics.push(...page.diagnostics);
+      if (page.timing) {
+        timings.push(page.timing);
+        addInitialTimingAggregate(timingAggregates, page.timing);
+      }
     }
 
     if (changes.length === 0) {
@@ -1354,6 +1459,14 @@ async function processInitialSyncPaged(
     }
 
     offset = nextOffset;
+  }
+
+  if (ctx.diagnosticsEnabled) {
+    diagnostics.push(...createInitialKindDiagnostics(timingAggregates));
+    const topRelations = createInitialRelationTopDiagnostics(timings);
+    if (topRelations) {
+      diagnostics.push(topRelations);
+    }
   }
 
   return {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -34,6 +34,7 @@ import { createSyncSchema } from "./sync-schema";
 
 const CORE_COL_DELETED = "deleted";
 const CORE_COL_LAST_MODIFIED_AT = "last_modified_at";
+const RPC_UNBOUNDED_PAGE_LIMIT = 2_147_483_647;
 
 export interface WorkerArtifacts extends SyncSchemaDeps {
   schemaTables: SchemaTables;
@@ -868,6 +869,11 @@ function getPrimaryKeyColumns(
   });
 }
 
+function getPrimaryKeyOrderColumns(tableName: string): string[] {
+  const primaryKey = getPrimaryKey(tableName);
+  return Array.isArray(primaryKey) ? primaryKey : [primaryKey];
+}
+
 /**
  * Extract rowId string from a row object.
  */
@@ -904,7 +910,12 @@ function extractRowId(
 async function fetchViaRPC(
   tx: Transaction,
   functionName: string,
-  params: Record<string, unknown>
+  params: Record<string, unknown>,
+  options: {
+    orderByColumns?: readonly string[];
+    pageLimit?: number;
+    pageOffset?: number;
+  } = {}
 ): Promise<Record<string, unknown>[]> {
   try {
     // Build: SELECT * FROM function_name($1::TYPE, $2::TYPE, ...)
@@ -947,7 +958,16 @@ async function fetchViaRPC(
       placeholders.push(cast ? `$${paramNum}::${cast}` : `$${paramNum}`);
     }
 
-    const queryString = `SELECT * FROM ${functionName}(${placeholders.join(", ")})`;
+    const orderBy = (options.orderByColumns ?? [])
+      .map((column) => `"${column.replaceAll('"', '""')}"`)
+      .join(", ");
+    let queryString = `SELECT * FROM ${functionName}(${placeholders.join(", ")})${orderBy ? ` ORDER BY ${orderBy}` : ""}`;
+    if (options.pageLimit !== undefined || options.pageOffset !== undefined) {
+      paramValues.push(options.pageLimit ?? RPC_UNBOUNDED_PAGE_LIMIT);
+      queryString += ` LIMIT $${paramValues.length}::INTEGER`;
+      paramValues.push(options.pageOffset ?? 0);
+      queryString += ` OFFSET $${paramValues.length}::INTEGER`;
+    }
 
     // Execute using the underlying session (bypassing Drizzle's sql template to avoid array wrapping)
     // Access the postgres-js client through the transaction's internal session
@@ -1455,12 +1475,16 @@ async function fetchTableForInitialSyncPage(
       rule,
       ctx,
       lastSyncAt: null,
-      pageLimit: limit,
-      pageOffset: offset,
+      pageLimit: RPC_UNBOUNDED_PAGE_LIMIT,
+      pageOffset: 0,
     });
 
     const queryStartedAt = Date.now();
-    const rows = await fetchViaRPC(tx, rule.functionName, rpcParams);
+    const rows = await fetchViaRPC(tx, rule.functionName, rpcParams, {
+      orderByColumns: getPrimaryKeyOrderColumns(tableName),
+      pageLimit: limit,
+      pageOffset: offset,
+    });
     const queryDurationMs = Date.now() - queryStartedAt;
 
     debug.log(
@@ -1661,6 +1685,7 @@ async function processInitialSyncPaged(
       timings,
       timingAggregates,
     });
+    pagesCollected += 1;
     const { changes } = page;
 
     if (changes.length === 0) {
@@ -1674,7 +1699,6 @@ async function processInitialSyncPaged(
     const nextOffset = offset + changes.length;
     const isLastPageForTable = changes.length < pageSize;
     allChanges.push(...changes);
-    pagesCollected += 1;
 
     if (isLastPageForTable) {
       tableIndex += 1;
@@ -1770,11 +1794,15 @@ async function fetchChangedRowsFromTable(
       rule,
       ctx,
       lastSyncAt,
-      pageLimit: 1000,
+      pageLimit: RPC_UNBOUNDED_PAGE_LIMIT,
       pageOffset: 0,
     });
 
-    const rows = await fetchViaRPC(tx, rule.functionName, rpcParams);
+    const rows = await fetchViaRPC(tx, rule.functionName, rpcParams, {
+      orderByColumns: getPrimaryKeyOrderColumns(tableName),
+      pageLimit: 1000,
+      pageOffset: 0,
+    });
 
     debug.log(
       `[PULL:INCR] ${tableName} (RPC): fetched ${rows.length} changed rows via ${rule.functionName} since ${lastSyncAt}`

--- a/worker/src/sync-schema.ts
+++ b/worker/src/sync-schema.ts
@@ -53,6 +53,8 @@ export interface TableMetaCore {
   booleanColumns: string[];
   supportsIncremental: boolean;
   hasDeletedFlag: boolean;
+  /** Optional relation kind for diagnostics; consumers may sync tables or views. */
+  relationKind?: "table" | "view" | "materialized_view" | string;
 }
 
 export interface SyncSchemaDeps {

--- a/worker/src/sync-schema.ts
+++ b/worker/src/sync-schema.ts
@@ -189,12 +189,17 @@ export function createSyncSchema(deps: SyncSchemaDeps) {
     tx: WorkerTransaction;
     userId: string;
     tables: SchemaTables;
+    collectionNames?: ReadonlySet<string>;
   }): Promise<Record<string, Set<string>>> {
     const collections = getWorkerConfig().collections ?? {};
     const result: Record<string, Set<string>> = {};
 
     // Load configured per-user collections.
     for (const [name, cfg] of Object.entries(collections)) {
+      if (params.collectionNames && !params.collectionNames.has(name)) {
+        continue;
+      }
+
       const table = params.tables[cfg.table];
       if (!table) {
         result[name] = new Set();

--- a/worker/src/sync-schema.ts
+++ b/worker/src/sync-schema.ts
@@ -54,7 +54,7 @@ export interface TableMetaCore {
   supportsIncremental: boolean;
   hasDeletedFlag: boolean;
   /** Optional relation kind for diagnostics; consumers may sync tables or views. */
-  relationKind?: "table" | "view" | "materialized_view" | string;
+  relationKind?: string;
 }
 
 export interface SyncSchemaDeps {


### PR DESCRIPTION
Order generated SYNCABLE_TABLES by the FK-derived TABLE_SYNC_ORDER so initial pull walks parent tables before dependent rows.

Add a focused table-order helper and tests, and feed the ordered table list through table metadata, app metadata, schema-key maps, and worker config generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated table metadata and downstream app/worker outputs now follow dependency-based ordering for more predictable sync.
  * Initial sync supports `initialPageCount` and now provides richer end-to-end diagnostics (including per-page details).
* **Bug Fixes**
  * Diagnostics enablement is more flexible (config + URL flags + persisted flags), and diagnostics logging is adjusted when enabled.
* **Tests**
  * Added coverage for dependency-based table ordering and `WorkerClient` request payloads (paging hints + diagnostics flag).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->